### PR TITLE
added clearing of unknown parameters map

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -270,6 +270,7 @@ void InitMaterial(material_t& material) {
     material.emission[i] = 0.f;
   }
   material.shininess = 1.f;
+  material.unknown_parameter.clear();
 }
 
 std::string LoadMtl (


### PR DESCRIPTION
not doing so caused undefined behavior in objects with multiple
materials using custom parameters.
