### PR TITLE
Cppcheck suggested performance improvement

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -196,12 +196,12 @@ updateVertex(
 static bool
 exportFaceGroupToShape(
   shape_t& shape,
-  const std::vector<float> in_positions,
-  const std::vector<float> in_normals,
-  const std::vector<float> in_texcoords,
+  const std::vector<float> &in_positions,
+  const std::vector<float> &in_normals,
+  const std::vector<float> &in_texcoords,
   const std::vector<std::vector<vertex_index> >& faceGroup,
-  const material_t material,
-  const std::string name)
+  const material_t &material,
+  const std::string &name)
 {
   if (faceGroup.empty()) {
     return false;


### PR DESCRIPTION
Cppcheck suggests:
variables should be passed by reference.
They are passed by value. It could be passed as a (const) reference which is usually faster and recommended in C++.

This gives a 9% performance boost in my project.
26.28s to load instead of 28.94s
