### PR TITLE
fix compiler warnings

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -178,7 +178,7 @@ updateVertex(
     return it->second;
   }
 
-  assert(in_positions.size() > (3*i.v_idx+2));
+  assert(in_positions.size() > (unsigned int) (3*i.v_idx+2));
 
   positions.push_back(in_positions[3*i.v_idx+0]);
   positions.push_back(in_positions[3*i.v_idx+1]);
@@ -721,4 +721,4 @@ std::string LoadObj(
 }
 
 
-};
+}

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -97,6 +97,6 @@ std::string LoadObj(
 std::string LoadMtl (
   std::map<std::string, material_t>& material_map,
   std::istream& inStream);
-};
+}
 
 #endif  // _TINY_OBJ_LOADER_H


### PR DESCRIPTION
I get these compiler warnings when using tinyobjloader in my own projects so I thought of fixing them.

```
tiny_obj_loader.h:100:2: warning: extra ';' [-Wpedantic]
 };
  ^
```

```
tiny_obj_loader.cc:181:44: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   assert(in_positions.size() > (3*i.v_idx+2));
```

```
tiny_obj_loader.cc:724:2: warning: extra ';' [-Wpedantic]
 };
  ^
```
