### PR TITLE
Fix unused variable warnings

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -238,10 +238,6 @@ exportFaceGroupToShape(
     return false;
   }
 
-  size_t offset;
-
-  offset = shape.mesh.indices.size();
-
   // Flatten vertices and indices
   for (size_t i = 0; i < faceGroup.size(); i++) {
     const std::vector<vertex_index>& face = faceGroup[i];
@@ -624,7 +620,6 @@ std::string LoadObj(
       token += 7;
       sscanf(token, "%s", namebuf);
 
-      bool ret = exportFaceGroupToShape(shape, vertexCache, v, vn, vt, faceGroup, material, name, false);
       faceGroup.clear();
 
       if (material_map.find(namebuf) != material_map.end()) {


### PR DESCRIPTION
My compiler (GCC 4.7.3) lists two variables as unused when I compile tinyobjloader.
I don't use all the features of tinyobjloader yet myself, but my program works fine with these modifications, and the tests still pass, so I believe they are indeed unsed and safe to remove!
