### PR TITLE
Bump MacOS image for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
         displayName: Check Python code format
 
   - job: macos
-    pool: {vmImage: 'macOS-10.13'}
+    pool: {vmImage: 'macOS-10.15'}
     variables:
       # Support C++11: https://github.com/joerick/cibuildwheel/pull/156
       MACOSX_DEPLOYMENT_TARGET: 10.9


### PR DESCRIPTION
The 10.13 image is being removed on 3/23.

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/