### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ One option is to simply copy the header file into your project and to make sure 
 
 Tinyobjlaoder is also available as a [conan package](https://bintray.com/conan/conan-center/tinyobjloader%3A_/_latestVersion). Conan integrates with many build systems and lets you avoid manual dependency installation. Their [documentation](https://docs.conan.io/en/latest/getting_started.html) is a great starting point.
 
-## Building tinyobjloader - Using vcpkg
+### Building tinyobjloader - Using vcpkg
 
 You can download and install tinyobjloader using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ One option is to simply copy the header file into your project and to make sure 
 
 Tinyobjlaoder is also available as a [conan package](https://bintray.com/conan/conan-center/tinyobjloader%3A_/_latestVersion). Conan integrates with many build systems and lets you avoid manual dependency installation. Their [documentation](https://docs.conan.io/en/latest/getting_started.html) is a great starting point.
 
+## Building tinyobjloader - Using vcpkg
+
+You can download and install tinyobjloader using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install tinyobjloader
+
+The tinyobjloader port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Data format
 
 `attrib_t` contains single and linear array of vertex data(position, normal and texcoord).


### PR DESCRIPTION
Tinyobjloader is available as a port in vcpkg, a C++ library manager that simplifies installation for tinyobjloader and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build tinyobjloader, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.