### PR TITLE
Use size_t rather than int in SplitString.

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1666,7 +1666,7 @@ static void SplitString(const std::string &s, char delim, char escape,
   std::string token;
 
   bool escaping = false;
-  for (int i = 0; i < s.size(); ++i) {
+  for (size_t i = 0; i < s.size(); ++i) {
     char ch = s[i];
     if (escaping) {
       escaping = false;


### PR DESCRIPTION
Hi!

Would it be possible to change int to size_t in SplitString?
This prevents a warning that currently occurs when tiny_obj_loader is compiled with -Wsign-compare.

Cheers!