### PR TITLE
Bump required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #This configures the Cmake system with multiple properties, depending
 #on the platform and configuration it is set to build in.
 project(tinyobjloader)
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.2)
 set(TINYOBJLOADER_SOVERSION 2)
 set(TINYOBJLOADER_VERSION 2.0.0-rc.8)
 


### PR DESCRIPTION
Avoids a warning when cmake is too old (2.8.11 is from 2013, 3.2 is from 2015)