### PR TITLE
Suppress clang warning: -Wdouble-promotion

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2453,7 +2453,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
         // TODO(syoyo): # of elements check
         parseReal2(&j, &w, &token, -1.0);
 
-        if (j < 0.0) {
+        if (j < static_cast<real_t>(0)) {
           if (err) {
             std::stringstream ss;
             ss << "Failed parse `vw' line. joint_id is negative. "


### PR DESCRIPTION
This PR fixes the following clang warning report:

```
./tiny_obj_loader.h:2456:13: warning: implicit conversion increases floating-point precision: 'tinyobj::real_t' (aka 'float') to 'double' [-Wdouble-promotion]
        if (j < 0.0) {
            ^ ~
```