### PR TITLE
undef max.

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -970,6 +970,9 @@ static bool tryParseDouble(const char *s, const char *s_end, double *result) {
     read = 0;
     end_not_reached = (curr != s_end);
     while (end_not_reached && IS_DIGIT(*curr)) {
+#ifdef max
+#undef max
+#endif
       if (exponent > std::numeric_limits<int>::max()/10) {
         // Integer overflow
         goto fail;


### PR DESCRIPTION
Windows defines max in minwindef.h:193:9 (on my machine) which leads to most compilers to being confused on which max to use.