### PR TITLE
Remove unnecessary ObjReader destructor

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -531,7 +531,6 @@ struct ObjReaderConfig {
 class ObjReader {
  public:
   ObjReader() : valid_(false) {}
-  ~ObjReader() {}
 
   ///
   /// Load .obj and .mtl from a file.


### PR DESCRIPTION
The destructor serves no purpose and is a pessimization in case the `ObjReader` class is every returned or moved around, as it inhibits move-constructor generation in C++11 and above.