### PR TITLE
Fix normal flipping during triangulation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ If you are looking for C89 version, please see https://github.com/syoyo/tinyobjl
 Version notice
 --------------
 
-We recommend to use `master`(`main`) branch. Its v2.0 release candidate. Most features are now nearly robust and stable(Remaining task for release v2.0 is polishing C++ and Python API).
+We recommend to use `master`(`main`) branch. Its v2.0 release candidate. Most features are now nearly robust and stable(Remaining task for release v2.0 is polishing C++ and Python API, and fix built-in triangulation code).
 
 We have released new version v1.0.0 on 20 Aug, 2016.
 Old version is available as `v0.9.x` branch https://github.com/syoyo/tinyobjloader/tree/v0.9.x
 
 ## What's new
 
-* 29 Jul, 2021 : Added Mapbox's earcut for robust triangulation. Also fixes triangulation bug.
+* 29 Jul, 2021 : Added Mapbox's earcut for robust triangulation. Also fixes triangulation bug(still there is some issue in built-in triangulation algorithm: https://github.com/tinyobjloader/tinyobjloader/issues/319).
 * 19 Feb, 2020 : The repository has been moved to https://github.com/tinyobjloader/tinyobjloader !
 * 18 May, 2019 : Python binding!(See `python` folder. Also see https://pypi.org/project/tinyobjloader/)
 * 14 Apr, 2019 : Bump version v2.0.0 rc0. New C++ API and python bindings!(1.x API still exists for backward compatibility)
@@ -106,10 +106,7 @@ TinyObjLoader is successfully used in ...
   * Vertex color(as an extension: https://blender.stackexchange.com/questions/31997/how-can-i-get-vertex-painted-obj-files-to-import-into-blender)
 * Texcoord
 * Normal
-* Material
-  * Unknown material attributes are returned as key-value(value is string) map.
 * Crease tag('t'). This is OpenSubdiv specific(not in wavefront .obj specification)
-* PBR material extension for .MTL. Its proposed here: http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
 * Callback API for custom loading.
 * Double precision support(for HPC application).
 * Smoothing group
@@ -126,12 +123,16 @@ TinyObjLoader is successfully used in ...
 * [ ] surface.
 * [ ] Free form curve/surfaces
 
+### Material
+
+* PBR material extension for .MTL. Its proposed here: http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
+* Texture options
+* Unknown material attributes are returned as key-value(value is string) map.
 
 ## TODO
 
 * [ ] Fix obj_sticker example.
 * [ ] More unit test codes.
-* [x] Texture options
 
 ## License
 

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1615,7 +1615,7 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           TinyObjPoint axis_w, axis_v, axis_u;
           axis_w = n;
           TinyObjPoint a;
-          if(abs(axis_w[0]) > 0.9999999) {
+          if(abs(axis_w.x) > 0.9999999) {
             a = TinyObjPoint(0,1,0);
           } else {
             a = TinyObjPoint(1,0,0);

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1399,30 +1399,30 @@ static int pnpoly(int nvert, T *vertx, T *verty, T testx, T testy) {
 
 
 inline std::array<real_t, 3> cross(const std::array<real_t, 3> &v1, const std::array<real_t, 3> &v2) {
-  return({v1[1] * v2[2] - v1[2] * v2[1]),
-          v1[2] * v2[0] - v1[0] * v2[2]),
-          v1[0] * v2[1] - v1[1] * v2[0]));
+  return { v1[1] * v2[2] - v1[2] * v2[1],
+          v1[2] * v2[0] - v1[0] * v2[2],
+          v1[0] * v2[1] - v1[1] * v2[0]};
 }
 
-inline Float dot(const std::array<real_t, 3> &v1, const std::array<real_t, 3> &v2) {
+inline real_t dot(const std::array<real_t, 3> &v1, const std::array<real_t, 3> &v2) {
   return (v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]);
 }
 
-inline Float GetLength(std::array<real_t, 3> &e) const { 
-	return std::sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]); 
+inline real_t GetLength(std::array<real_t, 3> &e) {
+	return std::sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
 }
 
-inline std::array<real_t, 3> Normalize(std::array<real_t, 3> e) const { 
+inline std::array<real_t, 3> Normalize(std::array<real_t, 3> e) {
 	real_t inv_length = 1.0 / GetLength(e);
-	return {e[0] * inv_length, e[1] * inv_length, e[2] * inv_length }; 
+	return {e[0] * inv_length, e[1] * inv_length, e[2] * inv_length };
 }
 
 
 inline std::array<real_t, 3> WorldToLocal(const std::array<real_t, 3>& a,
-										  const std::array<real_t, 3>& u, 
-										  const std::array<real_t, 3>& v, 
-										  const std::array<real_t, 3>& w) const {
-	std::array<real_t, 3> projected = {dot(a,u),dot(a,v),dot(a,w)}
+										  const std::array<real_t, 3>& u,
+										  const std::array<real_t, 3>& v,
+										  const std::array<real_t, 3>& w) {
+	std::array<real_t, 3> projected = {dot(a,u),dot(a,v),dot(a,w)};
     return(projected);
 }
 
@@ -1567,32 +1567,32 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
 #ifdef TINYOBJLOADER_USE_MAPBOX_EARCUT
           vertex_index_t i0 = face.vertex_indices[0];
           vertex_index_t i0_2 = i0;
-          
+
           // TMW change: Find the normal axis of the polygon using Newell's method
           using Point3 = std::array<real_t, 3>;
           Point3 n = {0, 0, 0};
           for (size_t k = 0; k < npolys; ++k) {
             i0 = face.vertex_indices[k % npolys];
             size_t vi0 = size_t(i0.v_idx);
-            
+
             size_t j = (k + 1) % npolys;
             i0_2 = face.vertex_indices[j];
             size_t vi0_2 = size_t(i0_2.v_idx);
-            
+
             real_t v0x = v[vi0 * 3 + 0];
             real_t v0y = v[vi0 * 3 + 1];
             real_t v0z = v[vi0 * 3 + 2];
-            
+
             real_t v0x_2 = v[vi0_2 * 3 + 0];
             real_t v0y_2 = v[vi0_2 * 3 + 1];
             real_t v0z_2 = v[vi0_2 * 3 + 2];
-            
+
             const Point3 point1 = {v0x,v0y,v0z};
             const Point3 point2 = {v0x_2,v0y_2,v0z_2};
-            
+
             Point3 a = {point1[0] - point2[0], point1[1] - point2[1], point1[2] - point2[2]};
             Point3 b = {point1[0] + point2[0], point1[1] + point2[1], point1[2] + point2[2]};
-            
+
             n[0] += (a[1] * b[2]);
             n[1] += (a[2] * b[0]);
             n[2] += (a[0] * b[1]);
@@ -1607,7 +1607,7 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           n[0] *= inv_length;
           n[1] *= inv_length;
           n[2] *= inv_length;
-          
+
           Point3 axis_w, axis_v, axis_u;
           axis_w = n;
           Point3 a;
@@ -1619,39 +1619,39 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           axis_v = Normalize(cross(axis_w, a));
           axis_u = cross(axis_w, axis_v);
           using Point = std::array<real_t, 2>;
-          
+
           // first polyline define the main polygon.
           // following polylines define holes(not used in tinyobj).
           std::vector<std::vector<Point> > polygon;
-          
+
           std::vector<Point> polyline;
-          
+
           //TMW change: Find best normal and project v0x and v0y to those coordinates, instead of
           //picking a plane aligned with an axis (which can flip polygons).
-          
+
           // Fill polygon data(facevarying vertices).
           for (size_t k = 0; k < npolys; k++) {
             i0 = face.vertex_indices[k];
             size_t vi0 = size_t(i0.v_idx);
-            
+
             assert(((3 * vi0 + 2) < v.size()));
-            
+
             real_t v0x = v[vi0 * 3 + 0];
             real_t v0y = v[vi0 * 3 + 1];
             real_t v0z = v[vi0 * 3 + 2];
-            
+
             Point3 polypoint = {v0x,v0y,v0z};
             Point3 loc = WorldToLocal(polypoint, axis_u, axis_v, axis_w);
-            
+
             polyline.push_back({loc[0], loc[1]});
           }
-          
+
           polygon.push_back(polyline);
           std::vector<uint32_t> indices = mapbox::earcut<uint32_t>(polygon);
           // => result = 3 * faces, clockwise
-          
+
           assert(indices.size() % 3 == 0);
-          
+
           // Reconstruct vertex_index_t
           for (size_t k = 0; k < indices.size() / 3; k++) {
             {
@@ -1671,23 +1671,23 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
                 face.vertex_indices[indices[3 * k + 2]].vn_idx;
               idx2.texcoord_index =
                 face.vertex_indices[indices[3 * k + 2]].vt_idx;
-              
+
               shape->mesh.indices.push_back(idx0);
               shape->mesh.indices.push_back(idx1);
               shape->mesh.indices.push_back(idx2);
-              
+
               shape->mesh.num_face_vertices.push_back(3);
               shape->mesh.material_ids.push_back(material_id);
               shape->mesh.smoothing_group_ids.push_back(
                   face.smoothing_group_id);
             }
           }
-          
+
 #else  // Built-in ear clipping triangulation
           vertex_index_t i0 = face.vertex_indices[0];
           vertex_index_t i1(-1);
           vertex_index_t i2 = face.vertex_indices[1];
-          
+
           // find the two axes to work in
           size_t axes[2] = {1, 2};
           for (size_t k = 0; k < npolys; ++k) {
@@ -1697,7 +1697,7 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
             size_t vi0 = size_t(i0.v_idx);
             size_t vi1 = size_t(i1.v_idx);
             size_t vi2 = size_t(i2.v_idx);
-            
+
             if (((3 * vi0 + 2) >= v.size()) || ((3 * vi1 + 2) >= v.size()) ||
                 ((3 * vi2 + 2) >= v.size())) {
               // Invalid triangle.

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1397,33 +1397,37 @@ static int pnpoly(int nvert, T *vertx, T *verty, T testx, T testy) {
   return c;
 }
 
+struct TinyObjPoint {
+  real_t x, y, z;
+  TinyObjPoint(real_t x_, real_t y_, real_t z_) :
+    x(x_), y(y_), z(z_) {}
+};
 
-inline std::array<real_t, 3> cross(const std::array<real_t, 3> &v1, const std::array<real_t, 3> &v2) {
-  return { v1[1] * v2[2] - v1[2] * v2[1],
-          v1[2] * v2[0] - v1[0] * v2[2],
-          v1[0] * v2[1] - v1[1] * v2[0]};
+inline TinyObjPoint cross(const TinyObjPoint &v1, const TinyObjPoint &v2) {
+  return TinyObjPoint(v1.y * v2.z - v1.z * v2.y,
+                      v1.z * v2.x - v1.x * v2.z,
+                      v1.x * v2.y - v1.y * v2.x);
 }
 
-inline real_t dot(const std::array<real_t, 3> &v1, const std::array<real_t, 3> &v2) {
-  return (v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]);
+inline real_t dot(const TinyObjPoint &v1, const TinyObjPoint &v2) {
+  return (v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);
 }
 
-inline real_t GetLength(std::array<real_t, 3> &e) {
-	return std::sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
+inline real_t GetLength(TinyObjPoint &e) {
+	return std::sqrt(e.x*e.x + e.y*e.y + e.z*e.z);
 }
 
-inline std::array<real_t, 3> Normalize(std::array<real_t, 3> e) {
+inline TinyObjPoint Normalize(TinyObjPoint e) {
 	real_t inv_length = 1.0 / GetLength(e);
-	return {e[0] * inv_length, e[1] * inv_length, e[2] * inv_length };
+	return TinyObjPoint(e.x * inv_length, e.y * inv_length, e.z * inv_length );
 }
 
 
-inline std::array<real_t, 3> WorldToLocal(const std::array<real_t, 3>& a,
-										  const std::array<real_t, 3>& u,
-										  const std::array<real_t, 3>& v,
-										  const std::array<real_t, 3>& w) {
-	std::array<real_t, 3> projected = {dot(a,u),dot(a,v),dot(a,w)};
-    return(projected);
+inline TinyObjPoint WorldToLocal(const TinyObjPoint& a,
+										  const TinyObjPoint& u,
+										  const TinyObjPoint& v,
+										  const TinyObjPoint& w) {
+  return TinyObjPoint(dot(a,u),dot(a,v),dot(a,w));
 }
 
 
@@ -1569,8 +1573,7 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           vertex_index_t i0_2 = i0;
 
           // TMW change: Find the normal axis of the polygon using Newell's method
-          using Point3 = std::array<real_t, 3>;
-          Point3 n = {0, 0, 0};
+          TinyObjPoint n(0, 0, 0);
           for (size_t k = 0; k < npolys; ++k) {
             i0 = face.vertex_indices[k % npolys];
             size_t vi0 = size_t(i0.v_idx);
@@ -1587,15 +1590,15 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
             real_t v0y_2 = v[vi0_2 * 3 + 1];
             real_t v0z_2 = v[vi0_2 * 3 + 2];
 
-            const Point3 point1 = {v0x,v0y,v0z};
-            const Point3 point2 = {v0x_2,v0y_2,v0z_2};
+            const TinyObjPoint point1(v0x,v0y,v0z);
+            const TinyObjPoint point2(v0x_2,v0y_2,v0z_2);
 
-            Point3 a = {point1[0] - point2[0], point1[1] - point2[1], point1[2] - point2[2]};
-            Point3 b = {point1[0] + point2[0], point1[1] + point2[1], point1[2] + point2[2]};
+            TinyObjPoint a(point1.x - point2.x, point1.y - point2.y, point1.z - point2.z);
+            TinyObjPoint b(point1.x + point2.x, point1.y + point2.y, point1.z + point2.z);
 
-            n[0] += (a[1] * b[2]);
-            n[1] += (a[2] * b[0]);
-            n[2] += (a[0] * b[1]);
+            n.x += (a.x * b.z);
+            n.y += (a.z * b.x);
+            n.z += (a.x * b.y);
           }
           real_t length_n = GetLength(n);
           //Check if zero length normal
@@ -1608,13 +1611,13 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           n[1] *= inv_length;
           n[2] *= inv_length;
 
-          Point3 axis_w, axis_v, axis_u;
+          TinyObjPoint axis_w, axis_v, axis_u;
           axis_w = n;
-          Point3 a;
+          TinyObjPoint a;
           if(abs(axis_w[0]) > 0.9999999) {
-            a = {0,1,0};
+            a = TinyObjPoint(0,1,0);
           } else {
-            a = {1,0,0};
+            a = TinyObjPoint(1,0,0);
           }
           axis_v = Normalize(cross(axis_w, a));
           axis_u = cross(axis_w, axis_v);
@@ -1640,10 +1643,10 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
             real_t v0y = v[vi0 * 3 + 1];
             real_t v0z = v[vi0 * 3 + 2];
 
-            Point3 polypoint = {v0x,v0y,v0z};
-            Point3 loc = WorldToLocal(polypoint, axis_u, axis_v, axis_w);
+            TinyObjPoint polypoint(v0x,v0y,v0z);
+            TinyObjPoint loc = WorldToLocal(polypoint, axis_u, axis_v, axis_w);
 
-            polyline.push_back({loc[0], loc[1]});
+            polyline.push_back({loc.x, loc.y});
           }
 
           polygon.push_back(polyline);

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1399,7 +1399,7 @@ static int pnpoly(int nvert, T *vertx, T *verty, T testx, T testy) {
 
 struct TinyObjPoint {
   real_t x, y, z;
-  TinyObjPoint() : x(0), y(0), z(0);
+  TinyObjPoint() : x(0), y(0), z(0) {}
   TinyObjPoint(real_t x_, real_t y_, real_t z_) :
     x(x_), y(y_), z(z_) {}
 };

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1399,6 +1399,7 @@ static int pnpoly(int nvert, T *vertx, T *verty, T testx, T testy) {
 
 struct TinyObjPoint {
   real_t x, y, z;
+  TinyObjPoint() : x(0), y(0), z(0);
   TinyObjPoint(real_t x_, real_t y_, real_t z_) :
     x(x_), y(y_), z(z_) {}
 };
@@ -1573,7 +1574,7 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           vertex_index_t i0_2 = i0;
 
           // TMW change: Find the normal axis of the polygon using Newell's method
-          TinyObjPoint n(0, 0, 0);
+          TinyObjPoint n;
           for (size_t k = 0; k < npolys; ++k) {
             i0 = face.vertex_indices[k % npolys];
             size_t vi0 = size_t(i0.v_idx);
@@ -1607,9 +1608,9 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
           }
           //Negative is to flip the normal to the correct direction
           real_t inv_length = -1.0f / length_n;
-          n[0] *= inv_length;
-          n[1] *= inv_length;
-          n[2] *= inv_length;
+          n.x *= inv_length;
+          n.y *= inv_length;
+          n.z *= inv_length;
 
           TinyObjPoint axis_w, axis_v, axis_u;
           axis_w = n;


### PR DESCRIPTION
This pull request fixes the triangulation issue by implementing Newell's method to ensure polygons aren't flipped, as well as turns off triangulation for faces when `npolys == 3`. I have confirmed it fixes all flipped normals on multiple large datasets with many polygonal faces. This fixes issue #319 .