### PR TITLE
Update Python README with modern build command

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -77,8 +77,8 @@ Edit `setup.py` and uncomment `Developer option` lines
 Assume pip is installed.
 
 ```
-$ pip install pybind11
-$ python setup.py build
+$ python -m pip install pybind11
+$ python -m pip install .
 ```
 
 ## License


### PR DESCRIPTION
Update Python README to current build command as the old one is broken an deprecated. The new command works for Python >=3.7 at least.

https://docs.python.org/3/installing/index.html#basic-usage
see https://docs.python.org/3/library/distutils.html