### PR TITLE
Add alternative aliases for displacement maps during mtl parsing

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2203,15 +2203,8 @@ void LoadMtl(std::map<std::string, int> *material_map,
     }
 
     // bump texture
-    if ((0 == strncmp(token, "map_bump", 8)) && IS_SPACE(token[8])) {
-      token += 9;
-      ParseTextureNameAndOption(&(material.bump_texname),
-                                &(material.bump_texopt), token);
-      continue;
-    }
-
-    // bump texture
-    if ((0 == strncmp(token, "map_Bump", 8)) && IS_SPACE(token[8])) {
+    if ((0 == strncmp(token, "map_bump", 8)) && IS_SPACE(token[8]) || 
+        (0 == strncmp(token, "map_Bump", 8)) && IS_SPACE(token[8])) {
       token += 9;
       ParseTextureNameAndOption(&(material.bump_texname),
                                 &(material.bump_texopt), token);
@@ -2232,6 +2225,15 @@ void LoadMtl(std::map<std::string, int> *material_map,
       material.alpha_texname = token;
       ParseTextureNameAndOption(&(material.alpha_texname),
                                 &(material.alpha_texopt), token);
+      continue;
+    }
+
+    // displacement texture
+    if ((0 == strncmp(token, "map_disp", 8)) && IS_SPACE(token[8]) ||
+        (0 == strncmp(token, "map_Disp", 8)) && IS_SPACE(token[8])) {
+      token += 9;
+      ParseTextureNameAndOption(&(material.displacement_texname),
+                                &(material.displacement_texopt), token);
       continue;
     }
 


### PR DESCRIPTION
Hi! I've recently tried loading [this](https://github.com/jimmiebergmann/Sponza) model using this library, but the displacement maps have not been loaded because the model uses `map_Disp` instead of `disp` in the mtl file. Now `map_Disp` is not a standard statement according to [this](http://paulbourke.net/dataformats/mtl/) specification, but [assimp](https://github.com/assimp/assimp/blob/master/code/AssetLib/Obj/ObjFileMtlImporter.cpp), for example, accepts it as valid, so I felt that it is probably common  enough to be supported in this library as well.