### PR TITLE
Update tiny_obj_loader.h

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1597,7 +1597,7 @@ static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
             TinyObjPoint a(point1.x - point2.x, point1.y - point2.y, point1.z - point2.z);
             TinyObjPoint b(point1.x + point2.x, point1.y + point2.y, point1.z + point2.z);
 
-            n.x += (a.x * b.z);
+            n.x += (a.y * b.z);
             n.y += (a.z * b.x);
             n.z += (a.x * b.y);
           }


### PR DESCRIPTION
This fixes the wrong axis (x instead of y) selected while calculating the polygon normal in Newell's method