### PR TITLE
Add missing initialization to member of callback_t

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -446,6 +446,7 @@ struct callback_t {
 
   callback_t()
       : vertex_cb(NULL),
+        vertex_color_cb(NULL),
         normal_cb(NULL),
         texcoord_cb(NULL),
         index_cb(NULL),


### PR DESCRIPTION
The `callback_t` had a member for vertex color callback that wasn't `null`-initialized like the other callbacks, leading to some pernicious traps for calling code. 