### PR TITLE
Added support for ambient occlusion texture

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -202,6 +202,7 @@ struct material_t {
   std::string displacement_texname;        // disp
   std::string alpha_texname;               // map_d
   std::string reflection_texname;          // refl
+  std::string ao_texname;                  // map_Po, mapao
 
   texture_option_t ambient_texopt;
   texture_option_t diffuse_texopt;
@@ -211,6 +212,7 @@ struct material_t {
   texture_option_t displacement_texopt;
   texture_option_t alpha_texopt;
   texture_option_t reflection_texopt;
+  texture_option_t ao_texopt;
 
   // PBR extension
   // http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
@@ -1364,6 +1366,7 @@ static void InitMaterial(material_t *material) {
   InitTexOpt(&material->displacement_texopt, /* is_bump */ false);
   InitTexOpt(&material->alpha_texopt, /* is_bump */ false);
   InitTexOpt(&material->reflection_texopt, /* is_bump */ false);
+  InitTexOpt(&material->ao_texopt, /* is_bump */ false);
   InitTexOpt(&material->roughness_texopt, /* is_bump */ false);
   InitTexOpt(&material->metallic_texopt, /* is_bump */ false);
   InitTexOpt(&material->sheen_texopt, /* is_bump */ false);
@@ -1379,6 +1382,7 @@ static void InitMaterial(material_t *material) {
   material->displacement_texname = "";
   material->reflection_texname = "";
   material->alpha_texname = "";
+  material->ao_texname = "";
   for (int i = 0; i < 3; i++) {
     material->ambient[i] = static_cast<real_t>(0.0);
     material->diffuse[i] = static_cast<real_t>(0.0);
@@ -2373,6 +2377,16 @@ void LoadMtl(std::map<std::string, int> *material_map,
       token += 5;
       ParseTextureNameAndOption(&(material.reflection_texname),
                                 &(material.reflection_texopt), token);
+      continue;
+    }
+
+    // ambient occlusion texture
+    if (((0 == strncmp(token, "map_Po", 6))||
+         (0 == strncmp(token, "map_ao", 6))) &&
+        IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.ao_texname),
+                                &(material.ao_texopt), token);
       continue;
     }
 

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -194,7 +194,7 @@ struct material_t {
 
   int dummy;  // Suppress padding warning.
 
-  std::string ambient_texname;             // map_Ka
+  std::string ambient_texname;             // map_Ka. For ambient or ambient occlusion.
   std::string diffuse_texname;             // map_Kd
   std::string specular_texname;            // map_Ks
   std::string specular_highlight_texname;  // map_Ns
@@ -2282,7 +2282,7 @@ void LoadMtl(std::map<std::string, int> *material_map,
       continue;
     }
 
-    // ambient texture
+    // ambient or ambient occlusion texture
     if ((0 == strncmp(token, "map_Ka", 6)) && IS_SPACE(token[6])) {
       token += 7;
       ParseTextureNameAndOption(&(material.ambient_texname),

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -202,7 +202,6 @@ struct material_t {
   std::string displacement_texname;        // disp
   std::string alpha_texname;               // map_d
   std::string reflection_texname;          // refl
-  std::string ao_texname;                  // map_Po, mapao
 
   texture_option_t ambient_texopt;
   texture_option_t diffuse_texopt;
@@ -212,7 +211,6 @@ struct material_t {
   texture_option_t displacement_texopt;
   texture_option_t alpha_texopt;
   texture_option_t reflection_texopt;
-  texture_option_t ao_texopt;
 
   // PBR extension
   // http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
@@ -1366,7 +1364,6 @@ static void InitMaterial(material_t *material) {
   InitTexOpt(&material->displacement_texopt, /* is_bump */ false);
   InitTexOpt(&material->alpha_texopt, /* is_bump */ false);
   InitTexOpt(&material->reflection_texopt, /* is_bump */ false);
-  InitTexOpt(&material->ao_texopt, /* is_bump */ false);
   InitTexOpt(&material->roughness_texopt, /* is_bump */ false);
   InitTexOpt(&material->metallic_texopt, /* is_bump */ false);
   InitTexOpt(&material->sheen_texopt, /* is_bump */ false);
@@ -1382,7 +1379,6 @@ static void InitMaterial(material_t *material) {
   material->displacement_texname = "";
   material->reflection_texname = "";
   material->alpha_texname = "";
-  material->ao_texname = "";
   for (int i = 0; i < 3; i++) {
     material->ambient[i] = static_cast<real_t>(0.0);
     material->diffuse[i] = static_cast<real_t>(0.0);
@@ -2377,16 +2373,6 @@ void LoadMtl(std::map<std::string, int> *material_map,
       token += 5;
       ParseTextureNameAndOption(&(material.reflection_texname),
                                 &(material.reflection_texopt), token);
-      continue;
-    }
-
-    // ambient occlusion texture
-    if (((0 == strncmp(token, "map_Po", 6))||
-         (0 == strncmp(token, "map_ao", 6))) &&
-        IS_SPACE(token[6])) {
-      token += 7;
-      ParseTextureNameAndOption(&(material.ao_texname),
-                                &(material.ao_texopt), token);
       continue;
     }
 


### PR DESCRIPTION
Added parsing for ambient occlsuion texture using `map_Po` or `map_ao`. Those were the only two variants that I found for ambient occlusion. I've ran across decent number of models that have AO textures but the corresponding MTL files have no way to specify it. 

I looked through the code, issues, and PRs and didn't find anything for ambient occlusion.  I wasn't sure if the existing ambient (`map_Ka`) is also meant for ambient occlusion. If that's the case please feel free to reject this PR.