### PR TITLE
Fix example writer transmittance

### DIFF
--- a/examples/obj_sticher/obj_writer.cc
+++ b/examples/obj_sticher/obj_writer.cc
@@ -26,7 +26,7 @@ bool WriteMat(const std::string& filename, const std::vector<tinyobj::material_t
     fprintf(fp, "Ka %f %f %f\n", mat.ambient[0], mat.ambient[1], mat.ambient[2]);
     fprintf(fp, "Kd %f %f %f\n", mat.diffuse[0], mat.diffuse[1], mat.diffuse[2]);
     fprintf(fp, "Ks %f %f %f\n", mat.specular[0], mat.specular[1], mat.specular[2]);
-    fprintf(fp, "Kt %f %f %f\n", mat.transmittance[0], mat.specular[1], mat.specular[2]);
+    fprintf(fp, "Kt %f %f %f\n", mat.transmittance[0], mat.transmittance[1], mat.transmittance[2]);
     fprintf(fp, "Ke %f %f %f\n", mat.emission[0], mat.emission[1], mat.emission[2]);
     fprintf(fp, "Ns %f\n", mat.shininess);
     fprintf(fp, "Ni %f\n", mat.ior);


### PR DESCRIPTION
[obj_writer.cc](https://github.com/tinyobjloader/tinyobjloader/blob/54684096e4ab1fcff9e7571888489e48d018c7fb/examples/obj_sticher/obj_writer.cc#L29) in `examples/obj_sticher` mistakenly wrote `mat.specular` into the `transmittance` attribute.

https://github.com/tinyobjloader/tinyobjloader/blob/54684096e4ab1fcff9e7571888489e48d018c7fb/examples/obj_sticher/obj_writer.cc#L29