### PR TITLE
Add Bazel build support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,9 @@
+cc_library(
+    name = "tinyobjloader",
+    hdrs = ["tiny_obj_loader.h"],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-Wno-maybe-uninitialized"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "tinyobjloader",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.8",
+)


### PR DESCRIPTION
This PR helps users of the [Bazel build system](https://bazel.build/) to integrate tinyobjloader in their builds.

In the worst case the Bazel build does simply not work - in the best case, someone who uses Bazel can benefit from it.

Also, other projects support Bazel side by side to other build systems (e.g. OpenEXR, Catch2, gtest, etc.)