### PR TITLE
Fix parsing of comments at the end of lines for tokens with variable number of elements. (#389)

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2708,7 +2708,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       sw.vertex_id = vid;
 
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         real_t j, w;
         // joint_id should not be negative, weight may be negative
         // TODO(syoyo): # of elements check
@@ -2749,7 +2749,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       __line_t line;
 
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         vertex_index_t vi;
         if (!parseTriple(&token, static_cast<int>(v.size() / 3),
                          static_cast<int>(vn.size() / 3),
@@ -2780,7 +2780,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       __points_t pts;
 
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         vertex_index_t vi;
         if (!parseTriple(&token, static_cast<int>(v.size() / 3),
                          static_cast<int>(vn.size() / 3),
@@ -2815,7 +2815,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
       face.smoothing_group_id = current_smoothing_id;
       face.vertex_indices.reserve(3);
 
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         vertex_index_t vi;
         if (!parseTriple(&token, static_cast<int>(v.size() / 3),
                          static_cast<int>(vn.size() / 3),
@@ -2951,7 +2951,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       std::vector<std::string> names;
 
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         std::string str = parseString(&token);
         names.push_back(str);
         token += strspn(token, " \t\r");  // skip tag
@@ -3245,7 +3245,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
       token += strspn(token, " \t");
 
       indices.clear();
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         vertex_index_t vi = parseRawTriple(&token);
 
         index_t idx;
@@ -3360,7 +3360,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
     if (token[0] == 'g' && IS_SPACE((token[1]))) {
       names.clear();
 
-      while (!IS_NEW_LINE(token[0])) {
+      while (!IS_NEW_LINE(token[0]) && token[0] != '#') {
         std::string str = parseString(&token);
         names.push_back(str);
         token += strspn(token, " \t\r");  // skip tag


### PR DESCRIPTION
This pull request should fix the problem described in issue #389 by cancelling the while loop when a `#` comment character is found.
Everything that follows after the `#` can be assumed to be part of the comment and should thus not be parsed.