### PR TITLE
Add remove Utf8 BOM

### DIFF
--- a/models/cube_w_BOM.mtl
+++ b/models/cube_w_BOM.mtl
@@ -1,0 +1,24 @@
+﻿newmtl white
+Ka 0 0 0
+Kd 1 1 1
+Ks 0 0 0
+
+newmtl red
+Ka 0 0 0
+Kd 1 0 0
+Ks 0 0 0
+
+newmtl green
+Ka 0 0 0
+Kd 0 1 0
+Ks 0 0 0
+
+newmtl blue
+Ka 0 0 0
+Kd 0 0 1
+Ks 0 0 0
+
+newmtl light
+Ka 20 20 20
+Kd 1 1 1
+Ks 0 0 0

--- a/models/cube_w_BOM.obj
+++ b/models/cube_w_BOM.obj
@@ -1,0 +1,32 @@
+﻿mtllib cube_w_BOM.mtl
+
+v 0.000000 2.000000 2.000000
+v 0.000000 0.000000 2.000000
+v 2.000000 0.000000 2.000000
+v 2.000000 2.000000 2.000000
+v 0.000000 2.000000 0.000000
+v 0.000000 0.000000 0.000000
+v 2.000000 0.000000 0.000000
+v 2.000000 2.000000 0.000000
+# 8 vertices
+
+g front cube
+usemtl white
+f 1 2 3 4
+# two white spaces between 'back' and 'cube'
+g back  cube
+# expects white material
+f 8 7 6 5
+g right cube
+usemtl red
+f 4 3 7 8
+g top cube
+usemtl white
+f 5 1 4 8
+g left cube
+usemtl green
+f 5 6 2 1
+g bottom cube
+usemtl white
+f 2 6 7 3
+# 6 elements

--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -1465,8 +1465,34 @@ void test_default_kd_for_multiple_materials_issue391() {
       std::cerr << "Unexpected material found!" << std::endl;
       TEST_CHECK(false);
     }
-  }
+  }  
 }
+
+void test_removeUtf8Bom() {
+  // Basic input with BOM
+  std::string withBOM = "\xEF\xBB\xBFhello world";
+  TEST_CHECK(tinyobj::removeUtf8Bom(withBOM) == "hello world");
+
+  // Input without BOM
+  std::string noBOM = "hello world";
+  TEST_CHECK(tinyobj::removeUtf8Bom(noBOM) == "hello world");
+
+  // Leaves short string unchanged
+  std::string shortStr = "\xEF";
+  TEST_CHECK(tinyobj::removeUtf8Bom(shortStr) == shortStr);
+
+  std::string shortStr2 = "\xEF\xBB";
+  TEST_CHECK(tinyobj::removeUtf8Bom(shortStr2) == shortStr2);
+
+  // BOM only returns empty string
+  std::string justBom = "\xEF\xBB\xBF";
+  TEST_CHECK(tinyobj::removeUtf8Bom(justBom) == "");
+
+  // Empty string
+  std::string emptyStr = "";
+  TEST_CHECK(tinyobj::removeUtf8Bom(emptyStr) == "");
+}
+
 
 // Fuzzer test.
 // Just check if it does not crash.
@@ -1579,4 +1605,5 @@ TEST_LIST = {
      test_invalid_texture_vertex_index},
     {"default_kd_for_multiple_materials_issue391",
      test_default_kd_for_multiple_materials_issue391},
+    {"test_removeUtf8Bom", test_removeUtf8Bom},
     {NULL, NULL}};

--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -1493,6 +1493,32 @@ void test_removeUtf8Bom() {
   TEST_CHECK(tinyobj::removeUtf8Bom(emptyStr) == "");
 }
 
+void test_loadObj_with_BOM() {
+  tinyobj::attrib_t attrib;
+  std::vector<tinyobj::shape_t> shapes;
+  std::vector<tinyobj::material_t> materials;
+
+  std::string warn;
+  std::string err;
+  bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
+                              "../models/cube_w_BOM.obj", gMtlBasePath);
+
+  if (!warn.empty()) {
+    std::cout << "WARN: " << warn << std::endl;
+  }
+
+  if (!err.empty()) {
+    std::cerr << "ERR: " << err << std::endl;
+  }
+
+  TEST_CHECK(true == ret);
+  TEST_CHECK(6 == shapes.size());
+  TEST_CHECK(0 == shapes[0].name.compare("front cube"));
+  TEST_CHECK(0 == shapes[1].name.compare("back cube"));  // multiple whitespaces
+                                                         // are aggregated as
+                                                         // single white space.
+}
+
 
 // Fuzzer test.
 // Just check if it does not crash.

--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -1632,4 +1632,5 @@ TEST_LIST = {
     {"default_kd_for_multiple_materials_issue391",
      test_default_kd_for_multiple_materials_issue391},
     {"test_removeUtf8Bom", test_removeUtf8Bom},
+    {"test_loadObj_with_BOM", test_loadObj_with_BOM},
     {NULL, NULL}};

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2651,7 +2651,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     if (linebuf.empty()) {
       continue;
     }
-    if (line_no == 1) {
+    if (line_num == 1) {
       linebuf = removeUtf8Bom(linebuf);
     }
 

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2651,7 +2651,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     if (linebuf.empty()) {
       continue;
     }
-    linebuf = removeUtf8Bom(linebuf);
+    if (line_no == 1) {
+      linebuf = removeUtf8Bom(linebuf);
+    }
 
     // Skip leading space.
     const char *token = linebuf.c_str();

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2121,7 +2121,9 @@ void LoadMtl(std::map<std::string, int> *material_map,
     if (linebuf.empty()) {
       continue;
     }
-    linebuf = removeUtf8Bom(linebuf);
+    if (line_no == 1) {
+      linebuf = removeUtf8Bom(linebuf);
+    }
 
     // Skip leading space.
     const char *token = linebuf.c_str();

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -810,7 +810,7 @@ static inline std::string toString(const T &t) {
   return ss.str();
 }
 
-std::string removeUtf8Bom(const std::string& input) {
+static inline std::string removeUtf8Bom(const std::string& input) {
     // UTF-8 BOM = 0xEF,0xBB,0xBF
     if (input.size() >= 3 &&
         static_cast<unsigned char>(input[0]) == 0xEF &&

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -810,6 +810,17 @@ static inline std::string toString(const T &t) {
   return ss.str();
 }
 
+std::string removeUtf8Bom(const std::string& input) {
+    // UTF-8 BOM = 0xEF,0xBB,0xBF
+    if (input.size() >= 3 &&
+        static_cast<unsigned char>(input[0]) == 0xEF &&
+        static_cast<unsigned char>(input[1]) == 0xBB &&
+        static_cast<unsigned char>(input[2]) == 0xBF) {
+        return input.substr(3); // Skip BOM
+    }
+    return input;
+}
+
 struct warning_context {
   std::string *warn;
   size_t line_number;
@@ -2110,6 +2121,7 @@ void LoadMtl(std::map<std::string, int> *material_map,
     if (linebuf.empty()) {
       continue;
     }
+    linebuf = removeUtf8Bom(linebuf);
 
     // Skip leading space.
     const char *token = linebuf.c_str();
@@ -2637,6 +2649,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     if (linebuf.empty()) {
       continue;
     }
+    linebuf = removeUtf8Bom(linebuf);
 
     // Skip leading space.
     const char *token = linebuf.c_str();


### PR DESCRIPTION
In the OBJ file if the first line starts with a invisible BOM char like: \uFEFFmtllib model.mtl 

```bash
paul@mac tinyobjloader % head -n 5 ../0FABEEBE-68BE-4F36-A268-CAE2853D08A8/model.obj | hexdump -C
00000000  ef bb bf 6d 74 6c 6c 69  62 20 6d 6f 64 65 6c 2e  |...mtllib model.|
00000010  6d 74 6c 0d 0a 67 20 5f  30 0d 0a 76 20 30 2e 36  |mtl..g _0..v 0.6|
00000020  38 35 36 34 30 20 35 2e  35 36 37 38 33 30 20 2d  |85640 5.567830 -|
00000030  31 2e 33 39 30 32 37 30  0d 0a 76 20 30 2e 36 38  |1.390270..v 0.68|
00000040  35 32 37 30 20 35 2e 35  33 38 30 33 30 20 2d 31  |5270 5.538030 -1|
00000050  2e 33 36 34 34 33 30 0d  0a 76 20 30 2e 36 38 39  |.364430..v 0.689|
00000060  37 37 30 20 35 2e 35 36  33 35 37 30 20 2d 31 2e  |770 5.563570 -1.|
00000070  33 39 30 32 37 30 0d 0a                           |390270..|
```

The parsing of the textures does not work in that case because of `if ((0 == strncmp(token, "mtllib", 6)) && IS_SPACE((token[6]))) {`