### PR TITLE
Add module interface file

### DIFF
--- a/examples/cxxmodule/CMakeLists.txt
+++ b/examples/cxxmodule/CMakeLists.txt
@@ -7,13 +7,13 @@ set(CMAKE_CXX_STANDARD 20)
 add_executable(main main.cc)
 
 # The module interface file requires the tiny_obj_loader header file
-target_include_directories(main PRIVATE "${CMAKE_SOURCE_DIR}/../..")
+target_include_directories(main PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 
 # Add the tiny_obj_loader module interface file
 target_sources(main PRIVATE
 	FILE_SET cxx_modules
 	TYPE CXX_MODULES
-	BASE_DIRS "${CMAKE_SOURCE_DIR}/../.."
-	FILES "${CMAKE_SOURCE_DIR}/../../tiny_obj_loader.cppm"
+	BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+	FILES "${CMAKE_CURRENT_SOURCE_DIR}/../../tiny_obj_loader.cppm"
 )
 

--- a/examples/cxxmodule/CMakeLists.txt
+++ b/examples/cxxmodule/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 4.0.0)
+
+project(CppmExample LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+
+add_executable(main main.cc)
+
+# The module interface file requires the tiny_obj_loader header file
+target_include_directories(main PRIVATE "${CMAKE_SOURCE_DIR}/../..")
+
+# Add the tiny_obj_loader module interface file
+target_sources(main PRIVATE
+	FILE_SET cxx_modules
+	TYPE CXX_MODULES
+	BASE_DIRS "${CMAKE_SOURCE_DIR}/../.."
+	FILES "${CMAKE_SOURCE_DIR}/../../tiny_obj_loader.cppm"
+)
+

--- a/examples/cxxmodule/main.cc
+++ b/examples/cxxmodule/main.cc
@@ -1,0 +1,28 @@
+#include <string>
+#include <vector>
+#include <iostream>
+
+// import std;
+import tinyobj;
+
+
+int main() {
+    // Equivalent to doing everything that #include <tiny_obj_loader.h> would do
+
+    const std::string filename = "../../models/cornell_box.obj";
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn, err;
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, filename.c_str())) {
+        throw std::runtime_error(warn + err);
+    }
+
+    std::cout << "shapes.size() = " << shapes.size() << std::endl;
+    for (const auto& shape : shapes) {
+        std::cout << "shape.mesh.indices.size() = " << shape.mesh.indices.size() << std::endl;
+    }
+
+    // ......
+}
+

--- a/tiny_obj_loader.cppm
+++ b/tiny_obj_loader.cppm
@@ -1,0 +1,65 @@
+module;
+
+#define TINYOBJLOADER_IMPLEMENTATION // optional
+#include <tiny_obj_loader.h>
+
+export module tinyobj;
+
+
+export namespace tinyobj {
+    using tinyobj::real_t;
+    using tinyobj::texture_type_t;
+    using tinyobj::texture_option_t;
+    using tinyobj::material_t;
+
+#ifdef TINY_OBJ_LOADER_PYTHON_BINDING
+    using tinyobj::GetDiffuse;
+    using tinyobj::GetSpecular;
+    using tinyobj::GetTransmittance;
+    using tinyobj::GetEmission;
+    using tinyobj::GetAmbient;
+    using tinyobj::SetDiffuse;
+    using tinyobj::SetAmbient;
+    using tinyobj::SetSpecular;
+    using tinyobj::SetTransmittance;
+    using tinyobj::GetCustomParameter;
+#endif // TINY_OBJ_LOADER_PYTHON_BINDING
+
+    using tinyobj::tag_t;
+    using tinyobj::joint_and_weight_t;
+    using tinyobj::skin_weight_t;
+    using tinyobj::index_t;
+    using tinyobj::mesh_t;
+    using tinyobj::lines_t;
+    using tinyobj::points_t;
+    using tinyobj::shape_t;
+    using tinyobj::attrib_t;
+    using tinyobj::callback_t;
+    using tinyobj::MaterialReader;
+    using tinyobj::MaterialFileReader;
+    using tinyobj::MaterialStreamReader;
+    using tinyobj::ObjReaderConfig;
+    using tinyobj::ObjReader;
+    using tinyobj::LoadObj;
+    using tinyobj::LoadObjWithCallback;
+    using tinyobj::LoadMtl;
+    using tinyobj::ParseTextureNameAndOption;
+
+
+    using tinyobj::vertex_index_t;
+    using tinyobj::face_t;
+    using tinyobj::__line_t;
+    using tinyobj::__points_t;
+    using tinyobj::tag_sizes;
+    using tinyobj::obj_shape;
+    using tinyobj::PrimGroup;
+
+    using tinyobj::warning_context;
+
+    using tinyobj::TinyObjPoint;
+    using tinyobj::cross;
+    using tinyobj::dot;
+    using tinyobj::GetLength;
+    using tinyobj::Normalize;
+    using tinyobj::WorldToLocal;
+}


### PR DESCRIPTION
Add a module interface file `tiny_obj_loader.cppm` that re-exports the contents of `tiny_obj_loader.h`. 

Also provide a simple example demonstrating its usage.