### PR TITLE
Add pure C11 loader (tiny_obj_c) with robust tessellation library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,76 @@ if (TINYOBJLOADER_WITH_PYTHON)
 
 endif()
 
+# ---------------------------------------------------------------------------
+# Pure C11 loader (tiny_obj_c + tobj_tess)
+# ---------------------------------------------------------------------------
+option(TINYOBJLOADER_BUILD_C_LIBRARY "Build the pure-C11 loader (tiny_obj_c)" ON)
+option(TINYOBJLOADER_C_ENABLE_FILE_IO "tiny_obj_c: file loading helpers" ON)
+option(TINYOBJLOADER_C_ENABLE_MMAP "tiny_obj_c: mmap-based file loading" OFF)
+option(TINYOBJLOADER_C_ENABLE_SIMD "tiny_obj_c: SIMD newline scan" OFF)
+option(TINYOBJLOADER_C_ENABLE_MULTITHREADING "tiny_obj_c: multithreaded parse" OFF)
+option(TINYOBJLOADER_C_BUILD_TESTS "tiny_obj_c: build C test drivers" OFF)
+
+if(TINYOBJLOADER_BUILD_C_LIBRARY)
+  enable_language(C)
+  set(CMAKE_C_STANDARD 11)
+  set(CMAKE_C_STANDARD_REQUIRED ON)
+  set(CMAKE_C_EXTENSIONS OFF)
+
+  add_library(tinyobjloader_c
+    ${CMAKE_CURRENT_SOURCE_DIR}/tiny_obj_c.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/tobj_tess.c)
+  add_sanitizers(tinyobjloader_c)
+  target_include_directories(tinyobjloader_c PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${TINYOBJLOADER_INCLUDE_DIR}>)
+
+  if(TINYOBJLOADER_C_ENABLE_FILE_IO)
+    target_compile_definitions(tinyobjloader_c PUBLIC TOBJ_ENABLE_FILE_IO)
+  endif()
+  if(TINYOBJLOADER_C_ENABLE_MMAP)
+    target_compile_definitions(tinyobjloader_c PUBLIC TOBJ_ENABLE_MMAP)
+  endif()
+  if(TINYOBJLOADER_C_ENABLE_SIMD)
+    target_compile_definitions(tinyobjloader_c PUBLIC TOBJ_ENABLE_SIMD)
+  endif()
+  if(TINYOBJLOADER_C_ENABLE_MULTITHREADING)
+    find_package(Threads REQUIRED)
+    target_compile_definitions(tinyobjloader_c PUBLIC TOBJ_ENABLE_MULTITHREADING)
+    target_link_libraries(tinyobjloader_c PUBLIC Threads::Threads)
+  endif()
+
+  install(TARGETS tinyobjloader_c
+    EXPORT ${PROJECT_NAME}-targets
+    DESTINATION ${TINYOBJLOADER_LIBRARY_DIR})
+  install(FILES
+    tiny_obj_c.h tiny_obj_c_pub.inc tiny_obj_c_impl.inc
+    tobj_tess.h tobj_tess_pub.inc tobj_tess_impl.inc
+    DESTINATION ${TINYOBJLOADER_INCLUDE_DIR})
+
+  if(TINYOBJLOADER_C_BUILD_TESTS)
+    add_executable(tester_c tests/tester_c.c)
+    target_link_libraries(tester_c tinyobjloader_c)
+    target_compile_definitions(tester_c PRIVATE TOBJ_ENABLE_FILE_IO)
+    add_executable(tess_tester tests/tess_tester.c
+      ${CMAKE_CURRENT_SOURCE_DIR}/tobj_tess.c)
+    target_include_directories(tess_tester PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    if(UNIX)
+      target_link_libraries(tester_c m)
+      target_link_libraries(tess_tester m)
+    endif()
+    enable_testing()
+    add_test(NAME tester_c COMMAND tester_c
+             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME tess_tester COMMAND tess_tester)
+  endif()
+
+  if(DEFINED ENV{LIB_FUZZING_ENGINE})
+    add_executable(fuzz_tobj_c fuzzer/fuzz_tobj_c.c)
+    target_link_libraries(fuzz_tobj_c tinyobjloader_c $ENV{LIB_FUZZING_ENGINE})
+  endif()
+endif()
+
 #Write CMake package config files
 include(CMakePackageConfigHelpers)
 

--- a/fuzzer/fuzz_tobj_c.c
+++ b/fuzzer/fuzz_tobj_c.c
@@ -1,0 +1,16 @@
+/*
+ * fuzz_tobj_c.c -- libFuzzer/AFL entry for the pure C11 loader.
+ *
+ * Build (libFuzzer):
+ *   clang -std=c11 -g -O1 -fsanitize=address,undefined,fuzzer \
+ *     -DTOBJ_ENABLE_FILE_IO -I.. fuzz_tobj_c.c ../tiny_obj_c.c ../tobj_tess.c \
+ *     -o fuzz_tobj_c
+ *
+ * tobj_fuzz_one parses the input from memory and frees the scene; the harness
+ * asserts only that it returns (no crash / hang / leak / UB).
+ */
+#include "tiny_obj_c.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  return tobj_fuzz_one(data, size);
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,18 @@
 .PHONY: clean check check_default check_features check_nofastfloat all \
-        obj-fuzz llvm-fuzz
+        obj-fuzz llvm-fuzz \
+        check_c check_c_default check_c_features check_tess check_c_freestanding
 
 CXX ?= clang++
 CXXFLAGS ?= -g -O1
 EXTRA_CXXFLAGS ?= -std=c++11 -fsanitize=address
+
+# ---- pure C11 loader (tiny_obj_c) -------------------------------------------
+CC ?= clang
+CFLAGS ?= -g -O1
+EXTRA_CFLAGS ?= -std=c11 -Wall -Wextra -fsanitize=address,undefined
+C_SRCS = ../tiny_obj_c.c ../tobj_tess.c
+C_DEPS = ../tiny_obj_c.h ../tiny_obj_c_pub.inc ../tiny_obj_c_impl.inc \
+         ../tobj_tess.h ../tobj_tess_pub.inc ../tobj_tess_impl.inc acutest.h
 
 # Optional feature macros exercised by the `tester_features` build.
 FEATURE_FLAGS = -DTINYOBJLOADER_USE_MULTITHREADING \
@@ -33,7 +42,30 @@ tester_nofastfloat: $(DEPS)
 	$(CXX) $(CXXFLAGS) $(EXTRA_CXXFLAGS) -DTINYOBJLOADER_DISABLE_FAST_FLOAT \
 		-pthread -I.. -o tester_nofastfloat $(SRCS)
 
-all: tester tester_features tester_nofastfloat
+all: tester tester_features tester_nofastfloat tester_c tess_tester \
+     tester_c_features
+
+# Default C build: scalar, single-threaded, file I/O + mmap, both precisions.
+tester_c: tester_c.c $(C_SRCS) $(C_DEPS)
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -DTOBJ_ENABLE_FILE_IO -DTOBJ_ENABLE_MMAP \
+		-I.. -o tester_c tester_c.c $(C_SRCS) -lm
+
+# Feature C build: exercise SIMD + multithreading paths.
+tester_c_features: tester_c.c $(C_SRCS) $(C_DEPS)
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -DTOBJ_ENABLE_FILE_IO -DTOBJ_ENABLE_MMAP \
+		-DTOBJ_ENABLE_SIMD -DTOBJ_ENABLE_MULTITHREADING -pthread \
+		-I.. -o tester_c_features tester_c.c $(C_SRCS) -lm
+
+# Tessellator unit/property tests.
+tess_tester: tess_tester.c ../tobj_tess.c ../tobj_tess.h ../tobj_tess_pub.inc \
+             ../tobj_tess_impl.inc acutest.h
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -I.. -o tess_tester tess_tester.c \
+		../tobj_tess.c -lm
+
+# Freestanding compile/link check: no libc, caller-supplied allocator.
+tester_c_freestanding: tester_c_freestanding.c $(C_SRCS) $(C_DEPS)
+	$(CC) $(CFLAGS) -std=c11 -Wall -Wextra -ffreestanding -DTOBJ_NO_LIBC \
+		-I.. -o tester_c_freestanding tester_c_freestanding.c $(C_SRCS)
 
 obj-fuzz:
 	$(MAKE) -C obj-fuzz
@@ -43,7 +75,7 @@ llvm-fuzz:
 
 # Run all configurations so CI covers the default, feature-enabled, and
 # fast_float-disabled code paths.
-check: check_default check_features check_nofastfloat
+check: check_default check_features check_nofastfloat check_c
 
 check_default: tester
 	./tester
@@ -54,7 +86,23 @@ check_features: tester_features
 check_nofastfloat: tester_nofastfloat
 	./tester_nofastfloat
 
+# Pure C11 test suite.
+check_c: check_c_default check_c_features check_tess check_c_freestanding
+
+check_c_default: tester_c
+	./tester_c
+
+check_c_features: tester_c_features
+	./tester_c_features
+
+check_tess: tess_tester
+	./tess_tester
+
+check_c_freestanding: tester_c_freestanding
+	./tester_c_freestanding
+
 clean:
-	rm -rf tester tester_features tester_nofastfloat
+	rm -rf tester tester_features tester_nofastfloat \
+	       tester_c tester_c_features tess_tester tester_c_freestanding
 	$(MAKE) -C obj-fuzz clean
 	$(MAKE) -C llvm-fuzz clean

--- a/tests/tess_tester.c
+++ b/tests/tess_tester.c
@@ -1,0 +1,217 @@
+/*
+ * tess_tester.c -- unit + property tests for tobj_tess (pure C11).
+ * Build via tests/Makefile (`tess_tester`) with ASan+UBSan.
+ */
+#include "acutest.h"
+#include "tobj_tess.h"
+
+#include <math.h>
+#include <string.h>
+
+#define MAXN 4096
+static uint32_t g_out[3 * MAXN];
+static unsigned char g_scratch[1 << 20];
+
+/* Run the double tessellator on an xyz ring; returns the result. */
+static tobj_tess_result run_d(const double *pts, uint32_t n) {
+  tobj_tess_desc_d d;
+  memset(&d, 0, sizeof d);
+  d.points = pts;
+  d.n = n;
+  d.out_indices = g_out;
+  d.out_cap = 3 * MAXN;
+  d.scratch = g_scratch;
+  d.scratch_size = sizeof g_scratch;
+  tobj_tess_result r;
+  tobj_tess_polygon_d(&d, &r);
+  return r;
+}
+
+/* Shared invariant checks: count == n-2, all indices in [0,n), no repeats in a
+ * triangle, status not OOM/INVALID for n>=3. */
+static void check_invariants(const double *pts, uint32_t n) {
+  tobj_tess_result r = run_d(pts, n);
+  TEST_CHECK_(r.status != TOBJ_TESS_OOM, "n=%u not OOM", n);
+  TEST_CHECK_(r.status != TOBJ_TESS_INVALID, "n=%u not INVALID", n);
+  TEST_CHECK_(r.num_triangles == n - 2, "n=%u tris=%u expected %u", n,
+              r.num_triangles, n - 2);
+  for (uint32_t i = 0; i < r.num_triangles * 3; i++)
+    TEST_CHECK_(g_out[i] < n, "idx %u in range (<%u)", g_out[i], n);
+  for (uint32_t t = 0; t < r.num_triangles; t++) {
+    uint32_t a = g_out[3 * t], b = g_out[3 * t + 1], c = g_out[3 * t + 2];
+    TEST_CHECK_(a != b && b != c && a != c, "tri %u has distinct corners", t);
+  }
+}
+
+static void test_n_too_small(void) {
+  double p[] = {0, 0, 0, 1, 1, 1};
+  tobj_tess_result r = run_d(p, 2);
+  TEST_CHECK(r.status == TOBJ_TESS_INVALID);
+  TEST_CHECK(r.num_triangles == 0);
+}
+
+static void test_triangle(void) {
+  double p[] = {0, 0, 0, 1, 0, 0, 0, 1, 0};
+  check_invariants(p, 3);
+}
+
+static void test_square(void) {
+  double p[] = {0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0};
+  check_invariants(p, 4);
+}
+
+static void test_concave_L(void) {
+  double p[] = {0, 0, 0, 2, 0, 0, 2, 1, 0, 1, 1, 0, 1, 2, 0, 0, 2, 0};
+  check_invariants(p, 6);
+}
+
+static void test_collinear_spike(void) {
+  double p[] = {0, 0, 0, 1, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0};
+  check_invariants(p, 5);
+}
+
+static void test_bowtie(void) {
+  double p[] = {0, 0, 0, 2, 2, 0, 2, 0, 0, 0, 2, 0};
+  tobj_tess_result r = run_d(p, 4);
+  TEST_CHECK(r.num_triangles == 2);
+  TEST_CHECK(r.status == TOBJ_TESS_DEGENERATE_BESTEFFORT);
+}
+
+static void test_big_coord_sliver(void) {
+  /* regression for the absolute-epsilon bug: tiny sliver at magnitude ~14000 */
+  double p[] = {14000, 14000, 0,        14000.001, 14000, 0,
+                14000.0005, 14000.0008, 0, 14000,   14000.001, 0};
+  check_invariants(p, 4);
+}
+
+static void test_coincident(void) {
+  double p[] = {5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
+  check_invariants(p, 5);
+}
+
+static void test_nonplanar(void) {
+  double p[] = {0, 0, 0,    2, 0, 0.3, 3, 1, -0.2,
+                2, 2, 0.1,  0, 2, 0.4, -1, 1, -0.3};
+  check_invariants(p, 6);
+}
+
+static void test_newell_zero(void) {
+  /* fully collinear: degenerate but must not crash, still n-2 tris */
+  double p[] = {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4};
+  tobj_tess_result r = run_d(p, 5);
+  TEST_CHECK(r.num_triangles == 3);
+  for (uint32_t i = 0; i < 9; i++) TEST_CHECK(g_out[i] < 5);
+}
+
+static void test_big_convex_fan(void) {
+  static double p[3 * 1000];
+  for (int i = 0; i < 1000; i++) {
+    double a = 2.0 * 3.14159265358979323846 * i / 1000.0;
+    p[3 * i] = cos(a);
+    p[3 * i + 1] = sin(a);
+    p[3 * i + 2] = 0;
+  }
+  check_invariants(p, 1000);
+}
+
+static void test_star_concave(void) {
+  static double p[3 * 12];
+  for (int i = 0; i < 12; i++) {
+    double a = 2.0 * 3.14159265358979323846 * i / 12.0;
+    double rr = (i & 1) ? 0.4 : 1.0;
+    p[3 * i] = rr * cos(a);
+    p[3 * i + 1] = rr * sin(a);
+    p[3 * i + 2] = 0;
+  }
+  check_invariants(p, 12);
+}
+
+/* Property: total triangle area ~= polygon area for a simple convex polygon. */
+static double tri_area(const double *a, const double *b, const double *c) {
+  return 0.5 * fabs((b[0] - a[0]) * (c[1] - a[1]) -
+                    (b[1] - a[1]) * (c[0] - a[0]));
+}
+static void test_area_preservation(void) {
+  /* planar (z=0) regular heptagon */
+  uint32_t n = 7;
+  static double p[3 * 7];
+  for (uint32_t i = 0; i < n; i++) {
+    double a = 2.0 * 3.14159265358979323846 * i / n;
+    p[3 * i] = 3.0 * cos(a);
+    p[3 * i + 1] = 3.0 * sin(a);
+    p[3 * i + 2] = 0;
+  }
+  /* shoelace area */
+  double poly = 0;
+  for (uint32_t i = 0; i < n; i++) {
+    uint32_t j = (i + 1) % n;
+    poly += p[3 * i] * p[3 * j + 1] - p[3 * j] * p[3 * i + 1];
+  }
+  poly = fabs(poly) * 0.5;
+  tobj_tess_result r = run_d(p, n);
+  double sum = 0;
+  for (uint32_t t = 0; t < r.num_triangles; t++)
+    sum += tri_area(&p[3 * g_out[3 * t]], &p[3 * g_out[3 * t + 1]],
+                    &p[3 * g_out[3 * t + 2]]);
+  TEST_CHECK_(fabs(sum - poly) < 1e-6 * poly, "tri area %.6f vs poly %.6f", sum,
+              poly);
+}
+
+/* Property: deterministic across two independent scratch buffers. */
+static void test_determinism(void) {
+  double p[] = {0, 0, 0, 2, 0, 0, 2, 1, 0, 1, 1, 0, 1, 2, 0, 0, 2, 0};
+  uint32_t n = 6;
+  uint32_t out1[3 * 6], out2[3 * 6];
+  unsigned char s1[4096], s2[4096];
+  tobj_tess_desc_d d;
+  memset(&d, 0, sizeof d);
+  d.points = p;
+  d.n = n;
+  tobj_tess_result r1, r2;
+  d.out_indices = out1;
+  d.out_cap = 18;
+  d.scratch = s1;
+  d.scratch_size = sizeof s1;
+  tobj_tess_polygon_d(&d, &r1);
+  d.out_indices = out2;
+  d.scratch = s2;
+  d.scratch_size = sizeof s2;
+  tobj_tess_polygon_d(&d, &r2);
+  TEST_CHECK(r1.num_triangles == r2.num_triangles);
+  for (uint32_t i = 0; i < r1.num_triangles * 3; i++)
+    TEST_CHECK(out1[i] == out2[i]);
+}
+
+/* float variant smoke: must match counts. */
+static void test_float_variant(void) {
+  float p[] = {0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0.5f, 1.5f, 0};
+  tobj_tess_desc_f d;
+  memset(&d, 0, sizeof d);
+  d.points = p;
+  d.n = 5;
+  d.out_indices = g_out;
+  d.out_cap = 3 * MAXN;
+  d.scratch = g_scratch;
+  d.scratch_size = sizeof g_scratch;
+  tobj_tess_result r;
+  tobj_tess_polygon_f(&d, &r);
+  TEST_CHECK(r.num_triangles == 3);
+}
+
+TEST_LIST = {
+    {"n_too_small", test_n_too_small},
+    {"triangle", test_triangle},
+    {"square", test_square},
+    {"concave_L", test_concave_L},
+    {"collinear_spike", test_collinear_spike},
+    {"bowtie", test_bowtie},
+    {"big_coord_sliver", test_big_coord_sliver},
+    {"coincident", test_coincident},
+    {"nonplanar", test_nonplanar},
+    {"newell_zero", test_newell_zero},
+    {"big_convex_fan", test_big_convex_fan},
+    {"star_concave", test_star_concave},
+    {"area_preservation", test_area_preservation},
+    {"determinism", test_determinism},
+    {"float_variant", test_float_variant},
+    {NULL, NULL}};

--- a/tests/tester_c.c
+++ b/tests/tester_c.c
@@ -44,16 +44,18 @@ static const char *load_string_f(const char *obj, tobj_scene_f *sc,
 
 /* ---- corpus ------------------------------------------------------------ */
 
+/* Only files committed to the repo (CI checks out a clean tree; sandbox/*.obj
+ * are local scratch files and are intentionally not used here). The
+ * pathological-geometry triangulation cases are covered directly by
+ * tests/tess_tester.c. */
 static const char *kCorpus[] = {
     "../models/cube.obj",
     "../models/cornell_box.obj",
     "../models/catmark_torus_creases0.obj",
     "../models/smoothing-group-two-squares.obj",
+    "../models/issue-162-smoothing-group.obj",
+    "../models/smoothing-normal.obj",
     "../models/issue-295-trianguation-failure.obj",
-    "../sandbox/zh2-ill.obj",
-    "../sandbox/ill-tri.obj",
-    "../sandbox/poly.obj",
-    "../sandbox/quad.obj",
     NULL};
 
 static void test_corpus_loads(void) {

--- a/tests/tester_c.c
+++ b/tests/tester_c.c
@@ -1,0 +1,219 @@
+/*
+ * tester_c.c -- loader tests for tiny_obj_c (pure C11, acutest).
+ * Run from the tests/ directory so that "../models/..." paths resolve.
+ * Built with TOBJ_ENABLE_FILE_IO + TOBJ_ENABLE_MMAP under ASan+UBSan.
+ */
+#include "acutest.h"
+#include "tiny_obj_c.h"
+
+#include <string.h>
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static tobj_result load_file_f(const char *path, tobj_scene_f *sc) {
+  tobj_load_config cfg = tobj_default_config();
+  return tobj_load_obj_from_file_f(sc, path, &cfg, NULL);
+}
+
+/* sum of per-face vertex counts must equal the index count */
+static int mesh_consistent_f(const tobj_scene_f *sc) {
+  for (size_t s = 0; s < sc->num_shapes; s++) {
+    const tobj_mesh_f *m = &sc->shapes[s].mesh;
+    size_t sum = 0;
+    for (size_t f = 0; f < m->num_faces; f++) sum += m->num_face_vertices[f];
+    if (sum != m->num_indices) return 0;
+    /* every index that references a vertex must be in range */
+    size_t numv = sc->attrib.vertices.count / 3;
+    for (size_t i = 0; i < m->num_indices; i++) {
+      int vi = m->indices[i].vertex_index;
+      if (vi >= 0 && (size_t)vi >= numv) return 0;
+    }
+  }
+  return 1;
+}
+
+static const char *load_string_f(const char *obj, tobj_scene_f *sc,
+                                  bool triangulate) {
+  tobj_load_config cfg = tobj_default_config();
+  cfg.triangulate = triangulate;
+  tobj_result r =
+      tobj_load_obj_from_memory_f(sc, (const uint8_t *)obj, strlen(obj), &cfg,
+                                  NULL);
+  return tobj_result_string(r);
+}
+
+/* ---- corpus ------------------------------------------------------------ */
+
+static const char *kCorpus[] = {
+    "../models/cube.obj",
+    "../models/cornell_box.obj",
+    "../models/catmark_torus_creases0.obj",
+    "../models/smoothing-group-two-squares.obj",
+    "../models/issue-295-trianguation-failure.obj",
+    "../sandbox/zh2-ill.obj",
+    "../sandbox/ill-tri.obj",
+    "../sandbox/poly.obj",
+    "../sandbox/quad.obj",
+    NULL};
+
+static void test_corpus_loads(void) {
+  for (int i = 0; kCorpus[i]; i++) {
+    tobj_scene_f sc;
+    tobj_result r = load_file_f(kCorpus[i], &sc);
+    TEST_CHECK_(r == TOBJ_OK, "%s -> %s", kCorpus[i], tobj_result_string(r));
+    if (r == TOBJ_OK) {
+      TEST_CHECK_(mesh_consistent_f(&sc), "%s mesh consistent", kCorpus[i]);
+      tobj_scene_free_f(&sc);
+    }
+  }
+}
+
+static void test_both_precisions(void) {
+  tobj_scene_f sf;
+  tobj_scene_d sd;
+  tobj_load_config cfg = tobj_default_config();
+  TEST_CHECK(tobj_load_obj_from_file_f(&sf, "../models/cube.obj", &cfg, NULL) ==
+             TOBJ_OK);
+  TEST_CHECK(tobj_load_obj_from_file_d(&sd, "../models/cube.obj", &cfg, NULL) ==
+             TOBJ_OK);
+  /* identical topology across precision families */
+  TEST_CHECK(sf.num_shapes == sd.num_shapes);
+  TEST_CHECK(sf.attrib.vertices.count == sd.attrib.vertices.count);
+  size_t fi = 0, di = 0;
+  for (size_t s = 0; s < sf.num_shapes; s++) fi += sf.shapes[s].mesh.num_indices;
+  for (size_t s = 0; s < sd.num_shapes; s++) di += sd.shapes[s].mesh.num_indices;
+  TEST_CHECK(fi == di);
+  tobj_scene_free_f(&sf);
+  tobj_scene_free_d(&sd);
+}
+
+/* ---- targeted regressions --------------------------------------------- */
+
+static void test_quad_triangulation(void) {
+  tobj_scene_f sc;
+  const char *obj = "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nf 1 2 3 4\n";
+  load_string_f(obj, &sc, true);
+  TEST_CHECK(sc.num_shapes == 1);
+  TEST_CHECK(sc.shapes[0].mesh.num_faces == 2);   /* 2 triangles */
+  TEST_CHECK(sc.shapes[0].mesh.num_indices == 6); /* 6 indices */
+  tobj_scene_free_f(&sc);
+}
+
+static void test_no_triangulation(void) {
+  tobj_scene_f sc;
+  const char *obj = "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nf 1 2 3 4\n";
+  load_string_f(obj, &sc, false);
+  TEST_CHECK(sc.shapes[0].mesh.num_faces == 1);
+  TEST_CHECK(sc.shapes[0].mesh.num_face_vertices[0] == 4);
+  TEST_CHECK(sc.shapes[0].mesh.num_indices == 4);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_negative_relative_index(void) {
+  tobj_scene_f sc;
+  /* -1 -2 -3 refer to the three most recent vertices */
+  const char *obj = "v 0 0 0\nv 1 0 0\nv 0 1 0\nf -3 -2 -1\n";
+  load_string_f(obj, &sc, true);
+  TEST_CHECK(sc.shapes[0].mesh.num_indices == 3);
+  TEST_CHECK(sc.shapes[0].mesh.indices[0].vertex_index == 0);
+  TEST_CHECK(sc.shapes[0].mesh.indices[1].vertex_index == 1);
+  TEST_CHECK(sc.shapes[0].mesh.indices[2].vertex_index == 2);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_bom_and_crlf(void) {
+  tobj_scene_f sc;
+  const char obj[] = "\xEF\xBB\xBFv 0 0 0\r\nv 1 0 0\r\nv 0 1 0\r\nf 1 2 3\r\n";
+  tobj_load_config cfg = tobj_default_config();
+  tobj_result r = tobj_load_obj_from_memory_f(&sc, (const uint8_t *)obj,
+                                              sizeof(obj) - 1, &cfg, NULL);
+  TEST_CHECK(r == TOBJ_OK);
+  TEST_CHECK(sc.attrib.vertices.count == 9);
+  TEST_CHECK(sc.shapes[0].mesh.num_indices == 3);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_vertex_colors(void) {
+  tobj_scene_f sc;
+  const char *obj = "v 0 0 0 1 0 0\nv 1 0 0 0 1 0\nv 0 1 0 0 0 1\nf 1 2 3\n";
+  load_string_f(obj, &sc, true);
+  TEST_CHECK(sc.attrib.colors.count == 9);
+  TEST_CHECK(sc.attrib.colors.ptr[0] == 1.0f); /* red on v0 */
+  TEST_CHECK(sc.attrib.colors.ptr[4] == 1.0f); /* green on v1 */
+  tobj_scene_free_f(&sc);
+}
+
+static void test_color_fallback_white(void) {
+  tobj_scene_f sc;
+  const char *obj = "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n";
+  load_string_f(obj, &sc, true);
+  TEST_CHECK(sc.attrib.colors.count == 9);
+  for (int i = 0; i < 9; i++) TEST_CHECK(sc.attrib.colors.ptr[i] == 1.0f);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_lines_and_points(void) {
+  tobj_scene_f sc;
+  const char *obj =
+      "v 0 0 0\nv 1 0 0\nv 2 0 0\nv 3 0 0\nl 1 2 3\np 1 4\n";
+  load_string_f(obj, &sc, true);
+  TEST_CHECK(sc.shapes[0].lines.num_lines == 1);
+  TEST_CHECK(sc.shapes[0].lines.num_indices == 3);
+  TEST_CHECK(sc.shapes[0].lines.num_line_vertices[0] == 3);
+  TEST_CHECK(sc.shapes[0].points.num_indices == 2);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_degenerate_face_skipped(void) {
+  tobj_scene_f sc;
+  const char *obj = "v 0 0 0\nv 1 0 0\nf 1 2\nf 1 2 1\n"; /* <3 verts skipped */
+  load_string_f(obj, &sc, true);
+  /* the 2-vertex face is skipped; the 3-"vertex" one is kept */
+  TEST_CHECK(sc.num_shapes == 1);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_empty_and_garbage(void) {
+  tobj_scene_f sc;
+  tobj_load_config cfg = tobj_default_config();
+  TEST_CHECK(tobj_load_obj_from_memory_f(&sc, (const uint8_t *)"", 0, &cfg,
+                                         NULL) == TOBJ_OK);
+  tobj_scene_free_f(&sc);
+  const char *garbage = "\x00\x01\x02 random !!! f f f\n v v v\n 99999999999";
+  TEST_CHECK(tobj_load_obj_from_memory_f(&sc, (const uint8_t *)garbage, 40,
+                                         &cfg, NULL) == TOBJ_OK);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_mtl_standalone(void) {
+  tobj_material_list_f ml;
+  const char *mtl =
+      "newmtl m\nKd 0.1 0.2 0.3\nNs 42\nmap_Kd -s 2 2 1 tex.png\nfoo bar baz\n";
+  tobj_result r =
+      tobj_parse_mtl_from_memory_f(&ml, (const uint8_t *)mtl, strlen(mtl), NULL,
+                                   NULL);
+  TEST_CHECK(r == TOBJ_OK);
+  TEST_CHECK(ml.count == 1);
+  TEST_CHECK(ml.items[0].diffuse[0] == 0.1f);
+  TEST_CHECK(ml.items[0].shininess == 42.0f);
+  TEST_CHECK(strcmp(ml.items[0].diffuse_texname, "tex.png") == 0);
+  TEST_CHECK(ml.items[0].diffuse_texopt.scale[0] == 2.0f);
+  const char *foo = tobj_material_get_param_f(&ml.items[0], "foo");
+  TEST_CHECK(foo && strcmp(foo, "bar baz") == 0);
+  tobj_material_list_free_f(&ml);
+}
+
+TEST_LIST = {
+    {"corpus_loads", test_corpus_loads},
+    {"both_precisions", test_both_precisions},
+    {"quad_triangulation", test_quad_triangulation},
+    {"no_triangulation", test_no_triangulation},
+    {"negative_relative_index", test_negative_relative_index},
+    {"bom_and_crlf", test_bom_and_crlf},
+    {"vertex_colors", test_vertex_colors},
+    {"color_fallback_white", test_color_fallback_white},
+    {"lines_and_points", test_lines_and_points},
+    {"degenerate_face_skipped", test_degenerate_face_skipped},
+    {"empty_and_garbage", test_empty_and_garbage},
+    {"mtl_standalone", test_mtl_standalone},
+    {NULL, NULL}};

--- a/tests/tester_c_freestanding.c
+++ b/tests/tester_c_freestanding.c
@@ -1,0 +1,65 @@
+/*
+ * tester_c_freestanding.c -- proves tiny_obj_c builds and runs with
+ * -ffreestanding -DTOBJ_NO_LIBC, using a caller-supplied bump allocator and
+ * no libc (no malloc / stdio / string.h). Returns 0 on success.
+ */
+#include "tiny_obj_c.h"
+
+static unsigned char g_pool[4u * 1024u * 1024u];
+static size_t g_used = 0;
+
+static void *fs_alloc(void *ud, size_t size, size_t align) {
+  (void)ud;
+  if (align < 1) align = 1;
+  size_t base = (size_t)(g_pool + g_used);
+  size_t aligned = (base + (align - 1)) & ~(size_t)(align - 1);
+  size_t off = aligned - (size_t)g_pool;
+  if (off + size > sizeof g_pool) return (void *)0;
+  g_used = off + size;
+  return (void *)aligned;
+}
+static void *fs_realloc(void *ud, void *ptr, size_t old, size_t neu,
+                        size_t align) {
+  void *p = fs_alloc(ud, neu, align);
+  if (p && ptr && old) {
+    unsigned char *d = (unsigned char *)p;
+    const unsigned char *s = (const unsigned char *)ptr;
+    size_t n = old < neu ? old : neu;
+    for (size_t i = 0; i < n; i++) d[i] = s[i];
+  }
+  return p;
+}
+static void fs_free(void *ud, void *p, size_t s) {
+  (void)ud;
+  (void)p;
+  (void)s;
+}
+
+static const char g_obj[] =
+    "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nvn 0 0 1\nf 1 2 3 4\nl 1 2\np 3\n";
+
+int main(void) {
+  tobj_allocator a;
+  a.alloc = fs_alloc;
+  a.realloc = fs_realloc;
+  a.free = fs_free;
+  a.user_data = (void *)0;
+
+  tobj_load_config cfg = tobj_default_config();
+  cfg.allocator = a;
+
+  size_t len = 0;
+  while (g_obj[len]) len++;
+
+  tobj_scene_f sc;
+  tobj_result r =
+      tobj_load_obj_from_memory_f(&sc, (const uint8_t *)g_obj, len, &cfg,
+                                  (tobj_diag *)0);
+  if (r != TOBJ_OK) return 1;
+  /* quad -> 2 triangles -> 6 indices */
+  int ok = (sc.num_shapes == 1 && sc.shapes[0].mesh.num_indices == 6 &&
+            sc.shapes[0].lines.num_lines == 1 &&
+            sc.shapes[0].points.num_indices == 1);
+  tobj_scene_free_f(&sc);
+  return ok ? 0 : 2;
+}

--- a/tiny_obj_c.c
+++ b/tiny_obj_c.c
@@ -1,0 +1,952 @@
+/*
+ * tiny_obj_c.c -- Pure C11 Wavefront .obj / .mtl loader implementation.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Layout:
+ *   [1] platform / header includes
+ *   [2] libc-independent mem helpers
+ *   [3] overflow-safe size arithmetic
+ *   [4] allocator + arena
+ *   [5] generic growable vector
+ *   [6] string interning
+ *   [7] number scanners (int / double / float)
+ *   [8] line index (scalar; SIMD in section [12])
+ *   [9] token cursor / lexer primitives
+ *   ... then tiny_obj_c_impl.inc is included once per precision.
+ */
+
+#include "tiny_obj_c.h"
+
+#ifndef TOBJ_NO_LIBC
+#include <stdlib.h> /* malloc/realloc/free */
+#endif
+
+#include <float.h>
+#include <limits.h>
+
+#if defined(TOBJ_ENABLE_SIMD)
+#if defined(__AVX2__) || defined(__SSE2__) || \
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
+#include <immintrin.h>
+#define TOBJ_SIMD_X86 1
+#elif defined(__ARM_NEON) || defined(__ARM_NEON__)
+#include <arm_neon.h>
+#define TOBJ_SIMD_NEON 1
+#endif
+#endif
+
+/* ======================================================================= */
+/* [2] libc-independent mem helpers                                        */
+/* ======================================================================= */
+
+static void *tobj_memcpy(void *dst, const void *src, size_t n) {
+  unsigned char *d = (unsigned char *)dst;
+  const unsigned char *s = (const unsigned char *)src;
+  for (size_t i = 0; i < n; i++) d[i] = s[i];
+  return dst;
+}
+
+static void *tobj_memset(void *dst, int c, size_t n) {
+  unsigned char *d = (unsigned char *)dst;
+  for (size_t i = 0; i < n; i++) d[i] = (unsigned char)c;
+  return dst;
+}
+
+static inline int tobj_memcmp(const void *a, const void *b, size_t n) {
+  const unsigned char *pa = (const unsigned char *)a;
+  const unsigned char *pb = (const unsigned char *)b;
+  for (size_t i = 0; i < n; i++) {
+    if (pa[i] != pb[i]) return (int)pa[i] - (int)pb[i];
+  }
+  return 0;
+}
+
+static size_t tobj_strlen(const char *s) {
+  size_t n = 0;
+  while (s[n]) n++;
+  return n;
+}
+
+static int tobj_strcmp(const char *a, const char *b) {
+  size_t i = 0;
+  for (;; i++) {
+    unsigned char ca = (unsigned char)a[i], cb = (unsigned char)b[i];
+    if (ca != cb) return (int)ca - (int)cb;
+    if (!ca) return 0;
+  }
+}
+
+/* Compare a (ptr,len) slice against a NUL-terminated literal for equality. */
+static bool tobj_slice_eq(const char *p, size_t len, const char *lit) {
+  for (size_t i = 0; i < len; i++) {
+    if (lit[i] == '\0' || p[i] != lit[i]) return false;
+  }
+  return lit[len] == '\0';
+}
+
+/* ======================================================================= */
+/* [3] overflow-safe size arithmetic                                       */
+/* ======================================================================= */
+
+static bool tobj_size_mul(size_t a, size_t b, size_t *out) {
+  if (a != 0 && b > (size_t)-1 / a) return false;
+  *out = a * b;
+  return true;
+}
+
+static bool tobj_size_add(size_t a, size_t b, size_t *out) {
+  if (a > (size_t)-1 - b) return false;
+  *out = a + b;
+  return true;
+}
+
+/* Clamp a size_t count into a non-negative int (saturating at INT_MAX). */
+static int tobj_size_to_int(size_t v) {
+  return v > (size_t)INT_MAX ? INT_MAX : (int)v;
+}
+
+/* ======================================================================= */
+/* [4] allocator + arena                                                   */
+/* ======================================================================= */
+
+#ifndef TOBJ_NO_LIBC
+static void *tobj_libc_alloc(void *ud, size_t size, size_t align) {
+  (void)ud;
+  (void)align; /* malloc already returns max_align_t-aligned storage */
+  return malloc(size ? size : 1);
+}
+static void *tobj_libc_realloc(void *ud, void *ptr, size_t old_size,
+                               size_t new_size, size_t align) {
+  (void)ud;
+  (void)old_size;
+  (void)align;
+  return realloc(ptr, new_size ? new_size : 1);
+}
+static void tobj_libc_free(void *ud, void *ptr, size_t size) {
+  (void)ud;
+  (void)size;
+  free(ptr);
+}
+tobj_allocator tobj_default_allocator(void) {
+  tobj_allocator a;
+  a.alloc = tobj_libc_alloc;
+  a.realloc = tobj_libc_realloc;
+  a.free = tobj_libc_free;
+  a.user_data = NULL;
+  return a;
+}
+#endif
+
+static void *tobj_alloc(const tobj_allocator *a, size_t size, size_t align) {
+  return a->alloc(a->user_data, size, align);
+}
+static void tobj_free(const tobj_allocator *a, void *ptr, size_t size) {
+  if (ptr) a->free(a->user_data, ptr, size);
+}
+static void *tobj_realloc(const tobj_allocator *a, void *ptr, size_t old_size,
+                          size_t new_size, size_t align) {
+  return a->realloc(a->user_data, ptr, old_size, new_size, align);
+}
+
+/* Arena: bump allocator over a linked list of blocks. Never frees one
+ * element; the whole arena is destroyed at once with the scene. */
+typedef struct tobj_arena_block {
+  struct tobj_arena_block *next;
+  size_t cap;
+  size_t used;
+  /* payload follows immediately after the header */
+} tobj_arena_block;
+
+typedef struct tobj_arena {
+  tobj_allocator alloc;
+  tobj_arena_block *head;
+  size_t default_block;
+} tobj_arena;
+
+#define TOBJ_ARENA_HDR \
+  ((sizeof(tobj_arena_block) + 15u) & ~(size_t)15u) /* 16-byte aligned hdr */
+
+static void tobj_arena_init(tobj_arena *ar, const tobj_allocator *a,
+                            size_t default_block) {
+  ar->alloc = *a;
+  ar->head = NULL;
+  ar->default_block = default_block ? default_block : (size_t)(64 * 1024);
+}
+
+static unsigned char *tobj_arena_block_data(tobj_arena_block *b) {
+  return (unsigned char *)b + TOBJ_ARENA_HDR;
+}
+
+static tobj_arena_block *tobj_arena_new_block(tobj_arena *ar, size_t min_bytes) {
+  size_t cap = ar->default_block;
+  if (cap < min_bytes) cap = min_bytes;
+  size_t total;
+  if (!tobj_size_add(TOBJ_ARENA_HDR, cap, &total)) return NULL;
+  tobj_arena_block *b =
+      (tobj_arena_block *)tobj_alloc(&ar->alloc, total, 16);
+  if (!b) return NULL;
+  b->cap = cap;
+  b->used = 0;
+  b->next = ar->head;
+  ar->head = b;
+  return b;
+}
+
+static void *tobj_arena_alloc(tobj_arena *ar, size_t size, size_t align) {
+  if (align < 1) align = 1;
+  if (size == 0) size = 1;
+  tobj_arena_block *b = ar->head;
+  if (b) {
+    size_t base = (size_t)(tobj_arena_block_data(b) + b->used);
+    size_t aligned = (base + (align - 1)) & ~(size_t)(align - 1);
+    size_t pad = aligned - base;
+    size_t need;
+    if (tobj_size_add(pad, size, &need) && b->used + need <= b->cap) {
+      b->used += need;
+      return (void *)aligned;
+    }
+  }
+  /* fresh block; over-allocate by alignment slack */
+  size_t want;
+  if (!tobj_size_add(size, align, &want)) return NULL;
+  b = tobj_arena_new_block(ar, want);
+  if (!b) return NULL;
+  size_t base = (size_t)tobj_arena_block_data(b);
+  size_t aligned = (base + (align - 1)) & ~(size_t)(align - 1);
+  b->used = (aligned - base) + size;
+  return (void *)aligned;
+}
+
+static void *tobj_arena_dup(tobj_arena *ar, const void *src, size_t size,
+                            size_t align) {
+  void *p = tobj_arena_alloc(ar, size, align);
+  if (p && src) tobj_memcpy(p, src, size);
+  return p;
+}
+
+static void tobj_arena_destroy(tobj_arena *ar) {
+  tobj_arena_block *b = ar->head;
+  while (b) {
+    tobj_arena_block *next = b->next;
+    tobj_free(&ar->alloc, b, TOBJ_ARENA_HDR + b->cap);
+    b = next;
+  }
+  ar->head = NULL;
+}
+
+/* ======================================================================= */
+/* [5] generic growable vector (type-erased, element-sized)                */
+/* ======================================================================= */
+
+typedef struct tobj_vec {
+  void *data;
+  size_t count; /* elements in use */
+  size_t cap;   /* element capacity */
+  size_t elem;  /* element size in bytes */
+} tobj_vec;
+
+static void tobj_vec_init(tobj_vec *v, size_t elem) {
+  v->data = NULL;
+  v->count = 0;
+  v->cap = 0;
+  v->elem = elem;
+}
+
+static void tobj_vec_free(tobj_vec *v, const tobj_allocator *a) {
+  if (v->data) {
+    size_t bytes;
+    if (!tobj_size_mul(v->cap, v->elem, &bytes)) bytes = 0;
+    tobj_free(a, v->data, bytes);
+  }
+  v->data = NULL;
+  v->count = v->cap = 0;
+}
+
+static bool tobj_vec_reserve(tobj_vec *v, size_t want, const tobj_allocator *a) {
+  if (want <= v->cap) return true;
+  size_t newcap = v->cap ? v->cap + v->cap / 2 : 8;
+  if (newcap < want) newcap = want;
+  size_t old_bytes, new_bytes;
+  if (!tobj_size_mul(v->cap, v->elem, &old_bytes)) return false;
+  if (!tobj_size_mul(newcap, v->elem, &new_bytes)) return false;
+  void *p = tobj_realloc(a, v->data, old_bytes, new_bytes, 16);
+  if (!p) return false;
+  v->data = p;
+  v->cap = newcap;
+  return true;
+}
+
+/* Append one zeroed element; returns a pointer to it, or NULL on OOM. */
+static void *tobj_vec_push(tobj_vec *v, const tobj_allocator *a) {
+  if (!tobj_vec_reserve(v, v->count + 1, a)) return NULL;
+  void *slot = (unsigned char *)v->data + v->count * v->elem;
+  tobj_memset(slot, 0, v->elem);
+  v->count++;
+  return slot;
+}
+
+/* Append `n` raw elements from `src` (src may be NULL to leave uninit). */
+static bool tobj_vec_append(tobj_vec *v, const void *src, size_t n,
+                            const tobj_allocator *a) {
+  size_t need;
+  if (!tobj_size_add(v->count, n, &need)) return false;
+  if (!tobj_vec_reserve(v, need, a)) return false;
+  if (src) {
+    size_t bytes;
+    if (!tobj_size_mul(n, v->elem, &bytes)) return false;
+    tobj_memcpy((unsigned char *)v->data + v->count * v->elem, src, bytes);
+  }
+  v->count += n;
+  return true;
+}
+
+static void *tobj_vec_at(tobj_vec *v, size_t i) {
+  return (unsigned char *)v->data + i * v->elem;
+}
+
+/* Copy a vector's used contents into freshly arena-allocated storage.
+ * Returns NULL when count==0 (callers treat that as an empty buffer). */
+static void *tobj_vec_finalize(tobj_vec *v, tobj_arena *ar, size_t align) {
+  if (v->count == 0) return NULL;
+  size_t bytes;
+  if (!tobj_size_mul(v->count, v->elem, &bytes)) return NULL;
+  return tobj_arena_dup(ar, v->data, bytes, align);
+}
+
+/* ======================================================================= */
+/* [6] string interning                                                    */
+/* ======================================================================= */
+
+/* Copy a (ptr,len) slice into the arena as a NUL-terminated string.
+ * Returns the empty string "" for len==0 (never NULL on success). */
+static const char *tobj_intern(tobj_arena *ar, const char *p, size_t len) {
+  char *s = (char *)tobj_arena_alloc(ar, len + 1, 1);
+  if (!s) return NULL;
+  if (len) tobj_memcpy(s, p, len);
+  s[len] = '\0';
+  return s;
+}
+
+/* ======================================================================= */
+/* [7] number scanners (libc-free, slice-bounded)                          */
+/* ======================================================================= */
+
+static bool tobj_is_space(char c) { return c == ' ' || c == '\t'; }
+static bool tobj_is_digit(char c) { return c >= '0' && c <= '9'; }
+
+static void tobj_skip_space(const char **pp, const char *end) {
+  const char *p = *pp;
+  while (p < end && tobj_is_space(*p)) p++;
+  *pp = p;
+}
+
+/* Exact powers of ten representable in IEEE-754 double (1e0 .. 1e22). */
+static const double tobj_pow10_tab[23] = {
+    1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
+    1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22};
+
+static double tobj_scale_pow10(double mant, int exp10) {
+  /* Fast, correctly-rounded path: mant exact, |exp10| <= 22. */
+  if (exp10 == 0) return mant;
+  if (exp10 > 0) {
+    if (exp10 <= 22) return mant * tobj_pow10_tab[exp10];
+  } else {
+    if (exp10 >= -22) return mant / tobj_pow10_tab[-exp10];
+  }
+  /* Slow path: repeated multiply (slightly less precise, still finite). */
+  double scale = 1.0;
+  int e = exp10 < 0 ? -exp10 : exp10;
+  double base = 10.0;
+  while (e) {
+    if (e & 1) scale *= base;
+    base *= base;
+    e >>= 1;
+    if (scale == 0.0 || scale > 1e308) break;
+  }
+  return exp10 < 0 ? mant / scale : mant * scale;
+}
+
+static bool tobj_match_ci(const char **pp, const char *end, const char *word) {
+  const char *p = *pp;
+  size_t i = 0;
+  while (word[i]) {
+    if (p + i >= end) return false;
+    char c = p[i];
+    if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+    if (c != word[i]) return false;
+    i++;
+  }
+  *pp = p + i;
+  return true;
+}
+
+/* Parse a (possibly signed) floating point token. Maps non-finite words to
+ * finite OBJ-friendly values (nan->0, +/-inf->+/-DBL_MAX). */
+static bool tobj_scan_double(const char **pp, const char *end, double *out) {
+  tobj_skip_space(pp, end);
+  const char *p = *pp;
+  if (p >= end) return false;
+
+  int sign = 1;
+  if (*p == '+' || *p == '-') {
+    if (*p == '-') sign = -1;
+    p++;
+  }
+
+  /* nan / inf / infinity */
+  if (p < end && (*p == 'n' || *p == 'N')) {
+    const char *q = p;
+    if (tobj_match_ci(&q, end, "nan")) {
+      *out = 0.0;
+      *pp = q;
+      return true;
+    }
+  }
+  if (p < end && (*p == 'i' || *p == 'I')) {
+    const char *q = p;
+    if (tobj_match_ci(&q, end, "infinity") || tobj_match_ci(&q, end, "inf")) {
+      *out = sign < 0 ? -DBL_MAX : DBL_MAX;
+      *pp = q;
+      return true;
+    }
+  }
+
+  uint64_t mant = 0;
+  int mant_digits = 0; /* significant digits accumulated into `mant` */
+  int frac_digits = 0; /* digits after the decimal point */
+  int extra_exp = 0;   /* integer digits dropped past 19 */
+  bool any_digit = false;
+  bool seen_dot = false;
+
+  for (; p < end; p++) {
+    char c = *p;
+    if (tobj_is_digit(c)) {
+      any_digit = true;
+      if (mant_digits < 19) {
+        mant = mant * 10u + (uint64_t)(c - '0');
+        mant_digits++;
+        if (seen_dot) frac_digits++;
+      } else {
+        /* too many significant digits: keep magnitude via exponent */
+        if (!seen_dot) extra_exp++;
+      }
+    } else if (c == '.' && !seen_dot) {
+      seen_dot = true;
+    } else {
+      break;
+    }
+  }
+  if (!any_digit) return false;
+
+  int exp10 = 0;
+  if (p < end && (*p == 'e' || *p == 'E')) {
+    const char *q = p + 1;
+    int esign = 1;
+    if (q < end && (*q == '+' || *q == '-')) {
+      if (*q == '-') esign = -1;
+      q++;
+    }
+    if (q < end && tobj_is_digit(*q)) {
+      int e = 0;
+      while (q < end && tobj_is_digit(*q)) {
+        if (e < 100000) e = e * 10 + (*q - '0');
+        q++;
+      }
+      exp10 = esign * e;
+      p = q;
+    }
+    /* a lone 'e' with no digits is not part of the number; leave p as-is */
+  }
+
+  exp10 += extra_exp - frac_digits;
+  double value = tobj_scale_pow10((double)mant, exp10);
+  *out = sign < 0 ? -value : value;
+  *pp = p;
+  return true;
+}
+
+/* Parse a (possibly signed) integer token (saturating to int range). */
+static bool tobj_scan_int(const char **pp, const char *end, int *out) {
+  tobj_skip_space(pp, end);
+  const char *p = *pp;
+  if (p >= end) return false;
+  int sign = 1;
+  if (*p == '+' || *p == '-') {
+    if (*p == '-') sign = -1;
+    p++;
+  }
+  if (p >= end || !tobj_is_digit(*p)) return false;
+  long long v = 0;
+  bool sat = false;
+  while (p < end && tobj_is_digit(*p)) {
+    if (!sat) {
+      v = v * 10 + (*p - '0');
+      if (v > 2147483647LL) {
+        v = 2147483647LL;
+        sat = true;
+      }
+    }
+    p++;
+  }
+  *out = (int)(sign < 0 ? -v : v);
+  *pp = p;
+  return true;
+}
+
+/* ======================================================================= */
+/* [8] line index (scalar)                                                 */
+/* ======================================================================= */
+
+typedef struct tobj_line {
+  size_t pos; /* byte offset of first char */
+  size_t len; /* length excluding the line terminator */
+} tobj_line;
+
+/* Skip a leading UTF-8 BOM if present. */
+static size_t tobj_skip_bom(const uint8_t *buf, size_t len) {
+  if (len >= 3 && buf[0] == 0xEF && buf[1] == 0xBB && buf[2] == 0xBF) return 3;
+  return 0;
+}
+
+/* Index of the next '\n' or '\r' at or after i, or len if none. SIMD when
+ * available; the scalar tail and fallback are always correct. */
+static size_t tobj_next_eol(const uint8_t *b, size_t i, size_t len) {
+#if defined(TOBJ_SIMD_X86) && defined(__AVX2__)
+  const __m256i nl = _mm256_set1_epi8('\n');
+  const __m256i cr = _mm256_set1_epi8('\r');
+  for (; i + 32 <= len; i += 32) {
+    __m256i v = _mm256_loadu_si256((const __m256i *)(b + i));
+    __m256i m = _mm256_or_si256(_mm256_cmpeq_epi8(v, nl),
+                                _mm256_cmpeq_epi8(v, cr));
+    unsigned mask = (unsigned)_mm256_movemask_epi8(m);
+    if (mask) return i + (size_t)__builtin_ctz(mask);
+  }
+#elif defined(TOBJ_SIMD_X86) && (defined(__SSE2__) || defined(_MSC_VER))
+  const __m128i nl = _mm_set1_epi8('\n');
+  const __m128i cr = _mm_set1_epi8('\r');
+  for (; i + 16 <= len; i += 16) {
+    __m128i v = _mm_loadu_si128((const __m128i *)(b + i));
+    __m128i m = _mm_or_si128(_mm_cmpeq_epi8(v, nl), _mm_cmpeq_epi8(v, cr));
+    unsigned mask = (unsigned)_mm_movemask_epi8(m);
+    if (mask) return i + (size_t)__builtin_ctz(mask);
+  }
+#elif defined(TOBJ_SIMD_NEON)
+  const uint8x16_t nl = vdupq_n_u8('\n');
+  const uint8x16_t cr = vdupq_n_u8('\r');
+  for (; i + 16 <= len; i += 16) {
+    uint8x16_t v = vld1q_u8(b + i);
+    uint8x16_t m = vorrq_u8(vceqq_u8(v, nl), vceqq_u8(v, cr));
+    if (vmaxvq_u8(m)) {
+      for (size_t j = 0; j < 16; j++)
+        if (b[i + j] == '\n' || b[i + j] == '\r') return i + j;
+    }
+  }
+#endif
+  while (i < len && b[i] != '\n' && b[i] != '\r') i++;
+  return i;
+}
+
+static bool tobj_build_line_index(const uint8_t *buf, size_t len, tobj_vec *out,
+                                  const tobj_allocator *a) {
+  size_t i = tobj_skip_bom(buf, len);
+  while (i < len) {
+    size_t e = tobj_next_eol(buf, i, len);
+    tobj_line *ln = (tobj_line *)tobj_vec_push(out, a);
+    if (!ln) return false;
+    ln->pos = i;
+    ln->len = e - i;
+    if (e >= len) break;
+    if (buf[e] == '\r' && e + 1 < len && buf[e + 1] == '\n') e++; /* CRLF */
+    i = e + 1;
+  }
+  return true;
+}
+
+/* ======================================================================= */
+/* [9] token cursor / lexer primitives                                     */
+/* ======================================================================= */
+
+/* A read cursor over a single logical line [p, end). */
+typedef struct tobj_cursor {
+  const char *p;
+  const char *end;
+} tobj_cursor;
+
+static void tobj_cur_init(tobj_cursor *c, const char *p, size_t len) {
+  c->p = p;
+  c->end = p + len;
+}
+
+/* Grab the next whitespace-delimited token. Returns false at end of line. */
+static bool tobj_next_token(tobj_cursor *c, const char **tok, size_t *tok_len) {
+  tobj_skip_space(&c->p, c->end);
+  if (c->p >= c->end) return false;
+  const char *start = c->p;
+  while (c->p < c->end && !tobj_is_space(*c->p)) c->p++;
+  *tok = start;
+  *tok_len = (size_t)(c->p - start);
+  return true;
+}
+
+/* ======================================================================= */
+/* [10] diagnostics, config, result strings (precision-independent)        */
+/* ======================================================================= */
+
+/* Append a fixed message to the diag sink. `msg` is NUL-terminated; no
+ * formatting is performed (freestanding-safe). */
+static void tobj_diag_append(tobj_diag *d, const tobj_allocator *a,
+                             tobj_severity sev, size_t line_no,
+                             const char *msg) {
+  if (!d) return;
+  if (d->on_message) {
+    d->on_message(d->user_data, sev, line_no, msg, tobj_strlen(msg));
+    return;
+  }
+  char **buf = (sev == TOBJ_SEV_ERROR) ? &d->err : &d->warn;
+  size_t *blen = (sev == TOBJ_SEV_ERROR) ? &d->err_len : &d->warn_len;
+  size_t add = tobj_strlen(msg);
+  size_t old = *blen;
+  size_t need;
+  if (!tobj_size_add(old, add, &need)) return;
+  if (!tobj_size_add(need, 1, &need)) return;
+  char *p = (char *)tobj_realloc(a, *buf, old ? old + 1 : 0, need, 1);
+  if (!p) return;
+  tobj_memcpy(p + old, msg, add);
+  p[old + add] = '\0';
+  *buf = p;
+  *blen = old + add;
+}
+
+void tobj_diag_free(tobj_diag *diag, const tobj_allocator *alloc) {
+  if (!diag) return;
+#ifndef TOBJ_NO_LIBC
+  tobj_allocator def = tobj_default_allocator();
+  if (!alloc) alloc = &def;
+#else
+  if (!alloc) return; /* cannot free without an allocator */
+#endif
+  if (diag->warn) {
+    tobj_free(alloc, diag->warn, diag->warn_len + 1);
+    diag->warn = NULL;
+    diag->warn_len = 0;
+  }
+  if (diag->err) {
+    tobj_free(alloc, diag->err, diag->err_len + 1);
+    diag->err = NULL;
+    diag->err_len = 0;
+  }
+}
+
+tobj_load_config tobj_default_config(void) {
+  tobj_load_config c;
+  tobj_memset(&c, 0, sizeof c);
+  c.triangulate = true;
+  c.store_vertex_colors = true;
+  c.vertex_color_fallback = true;
+  c.parse_freeform = false;
+  c.use_arena = false;
+  c.num_threads = -1;
+  /* 0 caps select built-in defaults in the loader */
+  return c;
+}
+
+const char *tobj_result_string(tobj_result r) {
+  switch (r) {
+    case TOBJ_OK: return "ok";
+    case TOBJ_ERR_INVALID_ARG: return "invalid argument";
+    case TOBJ_ERR_ALLOC: return "allocation failed";
+    case TOBJ_ERR_OVERFLOW: return "size overflow";
+    case TOBJ_ERR_PARSE: return "parse error";
+    case TOBJ_ERR_IO: return "I/O error";
+    case TOBJ_ERR_NOT_FOUND: return "not found";
+    case TOBJ_ERR_LIMIT_EXCEEDED: return "limit exceeded";
+    case TOBJ_ERR_UNSUPPORTED: return "unsupported";
+  }
+  return "unknown";
+}
+
+/* Unknown .mtl parameter pending finalization, tagged by material index. */
+typedef struct tobj_pending_kv {
+  size_t mat_index;
+  const char *key;
+  const char *value;
+} tobj_pending_kv;
+
+/* Resolve effective caps (0 => built-in default). */
+typedef struct tobj_caps {
+  size_t vertices, indices, faces, arity, materials, shapes, line_bytes;
+} tobj_caps;
+
+static tobj_caps tobj_resolve_caps(const tobj_load_config *cfg) {
+  tobj_caps c;
+  size_t big = (size_t)-1 / 64u;
+  c.vertices = cfg->max_vertices ? cfg->max_vertices : big;
+  c.indices = cfg->max_indices ? cfg->max_indices : big;
+  c.faces = cfg->max_faces ? cfg->max_faces : big;
+  c.arity = cfg->max_face_arity ? cfg->max_face_arity : (size_t)(1u << 20);
+  c.materials = cfg->max_materials ? cfg->max_materials : (size_t)(1u << 24);
+  c.shapes = cfg->max_shapes ? cfg->max_shapes : (size_t)(1u << 24);
+  c.line_bytes = cfg->max_line_bytes ? cfg->max_line_bytes : (size_t)(1u << 24);
+  return c;
+}
+
+/* ======================================================================= */
+/* [11] optional file I/O layer (TOBJ_ENABLE_FILE_IO / TOBJ_ENABLE_MMAP)   */
+/* ======================================================================= */
+
+#ifdef TOBJ_ENABLE_FILE_IO
+#include <stdio.h>
+#if defined(TOBJ_ENABLE_MMAP) && !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+typedef struct tobj_file_buf {
+  const uint8_t *data;
+  size_t len;
+  int mode; /* 0 = allocator buffer, 1 = mmap */
+  tobj_allocator alloc;
+} tobj_file_buf;
+
+static tobj_result tobj_file_open(tobj_file_buf *fb, const char *path,
+                                  const tobj_allocator *a) {
+  fb->data = NULL;
+  fb->len = 0;
+  fb->mode = 0;
+  fb->alloc = *a;
+
+#if defined(TOBJ_ENABLE_MMAP) && !defined(_WIN32)
+  {
+    int fd = open(path, O_RDONLY);
+    if (fd >= 0) {
+      struct stat st;
+      if (fstat(fd, &st) == 0 && st.st_size >= 0) {
+        size_t sz = (size_t)st.st_size;
+        if (sz == 0) {
+          close(fd);
+          fb->data = (const uint8_t *)"";
+          fb->len = 0;
+          fb->mode = 0;
+          return TOBJ_OK;
+        }
+        void *p = mmap(NULL, sz, PROT_READ, MAP_PRIVATE, fd, 0);
+        close(fd);
+        if (p != MAP_FAILED) {
+          fb->data = (const uint8_t *)p;
+          fb->len = sz;
+          fb->mode = 1;
+          return TOBJ_OK;
+        }
+      } else {
+        close(fd);
+      }
+    }
+    /* fall through to stdio on failure */
+  }
+#endif
+
+  {
+    FILE *f = fopen(path, "rb");
+    if (!f) return TOBJ_ERR_IO;
+    if (fseek(f, 0, SEEK_END) != 0) {
+      fclose(f);
+      return TOBJ_ERR_IO;
+    }
+    long sz = ftell(f);
+    if (sz < 0) {
+      fclose(f);
+      return TOBJ_ERR_IO;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+      fclose(f);
+      return TOBJ_ERR_IO;
+    }
+    uint8_t *buf = (uint8_t *)tobj_alloc(a, (size_t)sz ? (size_t)sz : 1, 16);
+    if (!buf) {
+      fclose(f);
+      return TOBJ_ERR_ALLOC;
+    }
+    size_t rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    fb->data = buf;
+    fb->len = rd;
+    fb->mode = 0;
+    return TOBJ_OK;
+  }
+}
+
+static void tobj_file_close(tobj_file_buf *fb) {
+  if (!fb->data) return;
+#if defined(TOBJ_ENABLE_MMAP) && !defined(_WIN32)
+  if (fb->mode == 1) {
+    if (fb->len) munmap((void *)fb->data, fb->len);
+    fb->data = NULL;
+    return;
+  }
+#endif
+  if (fb->mode == 0 && fb->len) tobj_free(&fb->alloc, (void *)fb->data, fb->len);
+  fb->data = NULL;
+}
+
+typedef struct tobj_file_res_ctx {
+  const char *basedir;
+  tobj_allocator alloc;
+} tobj_file_res_ctx;
+
+static void tobj_file_release(void *ud, const uint8_t *d, size_t n) {
+  (void)d;
+  (void)n;
+  tobj_file_buf *fb = (tobj_file_buf *)ud;
+  tobj_allocator a = fb->alloc;
+  tobj_file_close(fb);
+  tobj_free(&a, fb, sizeof *fb);
+}
+
+/* Default resolver: read "<basedir><name>" from disk. */
+static tobj_result tobj_file_material_resolver(void *ud, const char *name,
+                                               tobj_mtl_source *out) {
+  tobj_file_res_ctx *ctx = (tobj_file_res_ctx *)ud;
+  size_t bl = ctx->basedir ? tobj_strlen(ctx->basedir) : 0;
+  size_t nl = tobj_strlen(name);
+  size_t plen;
+  if (!tobj_size_add(bl, nl, &plen) || !tobj_size_add(plen, 1, &plen))
+    return TOBJ_ERR_OVERFLOW;
+  char *path = (char *)tobj_alloc(&ctx->alloc, plen, 1);
+  if (!path) return TOBJ_ERR_ALLOC;
+  if (bl) tobj_memcpy(path, ctx->basedir, bl);
+  tobj_memcpy(path + bl, name, nl);
+  path[bl + nl] = '\0';
+
+  tobj_file_buf *fb = (tobj_file_buf *)tobj_alloc(&ctx->alloc, sizeof *fb, 16);
+  if (!fb) {
+    tobj_free(&ctx->alloc, path, plen);
+    return TOBJ_ERR_ALLOC;
+  }
+  tobj_result r = tobj_file_open(fb, path, &ctx->alloc);
+  tobj_free(&ctx->alloc, path, plen);
+  if (r != TOBJ_OK) {
+    tobj_free(&ctx->alloc, fb, sizeof *fb);
+    return r;
+  }
+  out->data = fb->data;
+  out->len = fb->len;
+  out->release = tobj_file_release;
+  out->release_ud = fb;
+  return TOBJ_OK;
+}
+
+/* Directory prefix of `path` (including trailing separator), interned-style
+ * copy via allocator; returns "" when there is no separator. Caller frees. */
+static char *tobj_dirname_dup(const char *path, const tobj_allocator *a,
+                              size_t *out_len) {
+  size_t n = tobj_strlen(path);
+  size_t cut = 0;
+  for (size_t i = 0; i < n; i++) {
+    if (path[i] == '/' || path[i] == '\\') cut = i + 1;
+  }
+  char *d = (char *)tobj_alloc(a, cut + 1, 1);
+  if (!d) return NULL;
+  if (cut) tobj_memcpy(d, path, cut);
+  d[cut] = '\0';
+  *out_len = cut;
+  return d;
+}
+#endif /* TOBJ_ENABLE_FILE_IO */
+
+/* ======================================================================= */
+/* [11b] threading shim (TOBJ_ENABLE_MULTITHREADING)                       */
+/* ======================================================================= */
+
+#ifdef TOBJ_ENABLE_MULTITHREADING
+typedef struct tobj_thunk {
+  void (*fn)(void *);
+  void *arg;
+} tobj_thunk;
+
+#if defined(_WIN32)
+#include <windows.h>
+static DWORD WINAPI tobj_win_trampoline(LPVOID p) {
+  tobj_thunk *t = (tobj_thunk *)p;
+  t->fn(t->arg);
+  return 0;
+}
+static unsigned tobj_hw_threads(void) {
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return si.dwNumberOfProcessors ? si.dwNumberOfProcessors : 1u;
+}
+static void tobj_run_parallel(tobj_thunk *thunks, int n) {
+  HANDLE h[64];
+  int started = 0;
+  for (int i = 0; i < n && i < 64; i++) {
+    h[i] = CreateThread(NULL, 0, tobj_win_trampoline, &thunks[i], 0, NULL);
+    if (h[i]) started++; else thunks[i].fn(thunks[i].arg);
+  }
+  for (int i = 0; i < n && i < 64; i++)
+    if (h[i]) {
+      WaitForSingleObject(h[i], INFINITE);
+      CloseHandle(h[i]);
+    }
+  (void)started;
+}
+#else
+#include <pthread.h>
+#include <unistd.h>
+static void *tobj_pth_trampoline(void *p) {
+  tobj_thunk *t = (tobj_thunk *)p;
+  t->fn(t->arg);
+  return NULL;
+}
+static unsigned tobj_hw_threads(void) {
+  long n = sysconf(_SC_NPROCESSORS_ONLN);
+  return n > 0 ? (unsigned)n : 1u;
+}
+static void tobj_run_parallel(tobj_thunk *thunks, int n) {
+  pthread_t th[64];
+  int ok[64];
+  if (n > 64) n = 64;
+  for (int i = 0; i < n; i++)
+    ok[i] = (pthread_create(&th[i], NULL, tobj_pth_trampoline, &thunks[i]) == 0);
+  for (int i = 0; i < n; i++) {
+    if (ok[i])
+      pthread_join(th[i], NULL);
+    else
+      thunks[i].fn(thunks[i].arg); /* fallback: run inline */
+  }
+}
+#endif
+#endif /* TOBJ_ENABLE_MULTITHREADING */
+
+/* ======================================================================= */
+/* [12] per-precision parser instantiations                                */
+/* ======================================================================= */
+
+#include "tobj_tess.h"
+
+#define TOBJ_REAL float
+#define TOBJ_SUF _f
+#include "tiny_obj_c_impl.inc"
+#undef TOBJ_REAL
+#undef TOBJ_SUF
+
+#define TOBJ_REAL double
+#define TOBJ_SUF _d
+#include "tiny_obj_c_impl.inc"
+#undef TOBJ_REAL
+#undef TOBJ_SUF
+
+/* ======================================================================= */
+/* [12] fuzz entry                                                         */
+/* ======================================================================= */
+
+int tobj_fuzz_one(const uint8_t *data, size_t size) {
+  tobj_scene_f s;
+  tobj_load_config cfg = tobj_default_config();
+  if (tobj_load_obj_from_memory_f(&s, data, size, &cfg, NULL) == TOBJ_OK) {
+    tobj_scene_free_f(&s);
+  }
+  return 0;
+}

--- a/tiny_obj_c.h
+++ b/tiny_obj_c.h
@@ -1,0 +1,273 @@
+/*
+ * tiny_obj_c.h -- Pure C11 Wavefront .obj / .mtl loader.
+ *
+ * A from-scratch C11 reimplementation of tinyobjloader. NOT header-only:
+ * compile tiny_obj_c.c (and tobj_tess.c) and link against this header.
+ *
+ * Design goals: secure, portable, freestanding-capable, dependency-free,
+ * fast, robust. Multithreading / SIMD / mmap / file I/O are opt-in behind
+ * macros; the default build is scalar, single-threaded and libc-backed.
+ *
+ * Two precision families coexist in one build:
+ *   - "_f" suffix : float positions/normals/texcoords/materials
+ *   - "_d" suffix : double  ditto
+ * Pick whichever you need at the call site, or define TOBJ_DEFAULT_DOUBLE to
+ * make the unsuffixed convenience aliases map to the double family.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef TINY_OBJ_C_H_
+#define TINY_OBJ_C_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* ------------------------------------------------------------------------- */
+/* Configuration macros (see plan / README):                                 */
+/*                                                                           */
+/*   TOBJ_NO_LIBC / TOBJ_FREESTANDING : forbid libc; caller must supply an   */
+/*                                      allocator; no default file I/O.      */
+/*   TOBJ_ENABLE_FILE_IO              : tobj_load_obj_from_file_* helpers.   */
+/*   TOBJ_ENABLE_MMAP                 : use mmap / MapViewOfFile in file I/O. */
+/*   TOBJ_ENABLE_MULTITHREADING       : parallel chunked parse.             */
+/*   TOBJ_ENABLE_SIMD                 : SIMD newline scan.                   */
+/*   TOBJ_DISABLE_FAST_FLOAT          : scalar fallback float parser.        */
+/*   TOBJ_DEFAULT_DOUBLE              : unsuffixed aliases -> double family.  */
+/* ------------------------------------------------------------------------- */
+
+#if defined(TOBJ_FREESTANDING) && !defined(TOBJ_NO_LIBC)
+#define TOBJ_NO_LIBC 1
+#endif
+
+#if defined(TOBJ_NO_LIBC) && (defined(TOBJ_ENABLE_FILE_IO) || defined(TOBJ_ENABLE_MMAP))
+#error "TOBJ_NO_LIBC is incompatible with TOBJ_ENABLE_FILE_IO / TOBJ_ENABLE_MMAP"
+#endif
+
+#ifndef TOBJ_API
+#define TOBJ_API extern
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ======================================================================= */
+/* Precision-independent types                                             */
+/* ======================================================================= */
+
+/* Result / status codes. TOBJ_OK is returned even when non-fatal warnings
+ * were produced (parity with the C++ loader returning `true` plus a warn
+ * string). Any non-zero code is a hard failure; the output object is zeroed. */
+typedef enum tobj_result {
+  TOBJ_OK = 0,
+  TOBJ_ERR_INVALID_ARG,
+  TOBJ_ERR_ALLOC,
+  TOBJ_ERR_OVERFLOW,
+  TOBJ_ERR_PARSE,
+  TOBJ_ERR_IO,
+  TOBJ_ERR_NOT_FOUND,
+  TOBJ_ERR_LIMIT_EXCEEDED,
+  TOBJ_ERR_UNSUPPORTED
+} tobj_result;
+
+typedef enum tobj_severity {
+  TOBJ_SEV_WARNING = 0,
+  TOBJ_SEV_ERROR = 1
+} tobj_severity;
+
+/* Injectable allocator. If a config's allocator.alloc is NULL the default
+ * libc allocator is used (only available when !TOBJ_NO_LIBC). `align` is a
+ * power of two; realloc receives the previous size for arenas/bookkeeping. */
+typedef struct tobj_allocator {
+  void *(*alloc)(void *ud, size_t size, size_t align);
+  void *(*realloc)(void *ud, void *ptr, size_t old_size, size_t new_size,
+                   size_t align);
+  void (*free)(void *ud, void *ptr, size_t size);
+  void *user_data;
+} tobj_allocator;
+
+#ifndef TOBJ_NO_LIBC
+TOBJ_API tobj_allocator tobj_default_allocator(void);
+#endif
+
+/* Diagnostics sink. If on_message is non-NULL it is invoked per message and
+ * nothing is aggregated. Otherwise messages are appended to the `warn`/`err`
+ * buffers (allocated via the load config's allocator); free with
+ * tobj_diag_free. A NULL tobj_diag* passed to a loader silences diagnostics. */
+typedef struct tobj_diag {
+  void (*on_message)(void *ud, tobj_severity sev, size_t line_no,
+                     const char *msg, size_t msg_len);
+  void *user_data;
+  char *warn;
+  size_t warn_len;
+  char *err;
+  size_t err_len;
+} tobj_diag;
+
+TOBJ_API void tobj_diag_free(tobj_diag *diag, const tobj_allocator *alloc);
+
+/* Per-corner index triple. -1 means "not present". Precision-independent. */
+typedef struct tobj_index {
+  int vertex_index;
+  int normal_index;
+  int texcoord_index;
+} tobj_index;
+
+/* Key/value pair for material unknown_parameter maps (interned strings). */
+typedef struct tobj_kv {
+  const char *key;
+  const char *value;
+} tobj_kv;
+
+typedef enum tobj_texture_type {
+  TOBJ_TEXTURE_TYPE_NONE = 0,
+  TOBJ_TEXTURE_TYPE_SPHERE,
+  TOBJ_TEXTURE_TYPE_CUBE_TOP,
+  TOBJ_TEXTURE_TYPE_CUBE_BOTTOM,
+  TOBJ_TEXTURE_TYPE_CUBE_FRONT,
+  TOBJ_TEXTURE_TYPE_CUBE_BACK,
+  TOBJ_TEXTURE_TYPE_CUBE_LEFT,
+  TOBJ_TEXTURE_TYPE_CUBE_RIGHT
+} tobj_texture_type;
+
+/* Free-form curve/surface type (cstype). */
+typedef enum tobj_cstype {
+  TOBJ_CSTYPE_NONE = 0,
+  TOBJ_CSTYPE_BMATRIX,
+  TOBJ_CSTYPE_BEZIER,
+  TOBJ_CSTYPE_BSPLINE,
+  TOBJ_CSTYPE_CARDINAL,
+  TOBJ_CSTYPE_TAYLOR
+} tobj_cstype;
+
+/* Raw bytes for one .mtl source, produced by a material resolver. If
+ * `release` is set the loader calls it once it is done with the bytes. */
+typedef struct tobj_mtl_source {
+  const uint8_t *data;
+  size_t len;
+  void (*release)(void *ud, const uint8_t *data, size_t len);
+  void *release_ud;
+} tobj_mtl_source;
+
+/* Resolve a `mtllib` name to bytes. Return TOBJ_OK and fill *out, or
+ * TOBJ_ERR_NOT_FOUND (treated as a warning by the loader). Called once per
+ * distinct name encountered. Replaces the C++ virtual MaterialReader. */
+typedef tobj_result (*tobj_material_resolver)(void *ud, const char *mtllib_name,
+                                              tobj_mtl_source *out);
+
+/* Load configuration (precision-independent: it has no real fields). */
+typedef struct tobj_load_config {
+  tobj_allocator allocator;     /* {0} -> default libc allocator */
+
+  bool triangulate;             /* default true */
+  bool store_vertex_colors;     /* default true */
+  bool vertex_color_fallback;   /* fill missing colors with white; default true */
+  bool parse_freeform;          /* parse cstype/curv/surf/...; default false */
+  bool use_arena;               /* bulk-arena output; default false */
+
+  int num_threads;              /* -1 auto, 0/1 single-threaded (MT builds) */
+
+  /* Hard caps; 0 selects a built-in default. Exceeding -> LIMIT_EXCEEDED. */
+  size_t max_vertices;
+  size_t max_indices;
+  size_t max_faces;
+  size_t max_face_arity;
+  size_t max_materials;
+  size_t max_shapes;
+  size_t max_line_bytes;
+
+  tobj_material_resolver mtl_resolver;
+  void *mtl_resolver_user_data;
+} tobj_load_config;
+
+TOBJ_API tobj_load_config tobj_default_config(void);
+
+/* ======================================================================= */
+/* Per-precision types and API (generated for _f and _d)                   */
+/* ======================================================================= */
+
+#define TOBJ_CAT_(a, b) a##b
+#define TOBJ_CAT(a, b) TOBJ_CAT_(a, b)
+/* Paste the active precision suffix (TOBJ_SUF) onto an identifier. */
+#define TOBJ_T(name) TOBJ_CAT(name, TOBJ_SUF)
+
+/* float family */
+#define TOBJ_REAL float
+#define TOBJ_SUF _f
+#include "tiny_obj_c_pub.inc"
+#undef TOBJ_REAL
+#undef TOBJ_SUF
+
+/* double family */
+#define TOBJ_REAL double
+#define TOBJ_SUF _d
+#include "tiny_obj_c_pub.inc"
+#undef TOBJ_REAL
+#undef TOBJ_SUF
+
+/* Convenience aliases for the default precision.
+ *
+ * IMPORTANT: type aliases are typedefs and function aliases are *function-like*
+ * macros. Object-like macros sharing these base names would be expanded inside
+ * TOBJ_T()/TOBJ_CAT() token-pasting (which fully expands its arguments) and
+ * corrupt the suffixed identifiers in the implementation. Typedef names and
+ * unparenthesized function-like macro names are not expanded there, so both
+ * forms are safe. */
+#ifdef TOBJ_DEFAULT_DOUBLE
+typedef double tobj_real;
+typedef tobj_real_buf_d tobj_real_buf;
+typedef tobj_texture_option_d tobj_texture_option;
+typedef tobj_material_d tobj_material;
+typedef tobj_attrib_d tobj_attrib;
+typedef tobj_mesh_d tobj_mesh;
+typedef tobj_lines_d tobj_lines;
+typedef tobj_points_d tobj_points;
+typedef tobj_shape_d tobj_shape;
+typedef tobj_scene_d tobj_scene;
+typedef tobj_callbacks_d tobj_callbacks;
+typedef tobj_material_list_d tobj_material_list;
+
+#define tobj_load_obj_from_memory(...) tobj_load_obj_from_memory_d(__VA_ARGS__)
+#define tobj_load_obj_from_file(...) tobj_load_obj_from_file_d(__VA_ARGS__)
+#define tobj_load_obj_with_callbacks(...) \
+  tobj_load_obj_with_callbacks_d(__VA_ARGS__)
+#define tobj_scene_free(...) tobj_scene_free_d(__VA_ARGS__)
+#define tobj_parse_mtl_from_memory(...) tobj_parse_mtl_from_memory_d(__VA_ARGS__)
+#define tobj_material_list_free(...) tobj_material_list_free_d(__VA_ARGS__)
+#define tobj_material_get_param(...) tobj_material_get_param_d(__VA_ARGS__)
+#else
+typedef float tobj_real;
+typedef tobj_real_buf_f tobj_real_buf;
+typedef tobj_texture_option_f tobj_texture_option;
+typedef tobj_material_f tobj_material;
+typedef tobj_attrib_f tobj_attrib;
+typedef tobj_mesh_f tobj_mesh;
+typedef tobj_lines_f tobj_lines;
+typedef tobj_points_f tobj_points;
+typedef tobj_shape_f tobj_shape;
+typedef tobj_scene_f tobj_scene;
+typedef tobj_callbacks_f tobj_callbacks;
+typedef tobj_material_list_f tobj_material_list;
+
+#define tobj_load_obj_from_memory(...) tobj_load_obj_from_memory_f(__VA_ARGS__)
+#define tobj_load_obj_from_file(...) tobj_load_obj_from_file_f(__VA_ARGS__)
+#define tobj_load_obj_with_callbacks(...) \
+  tobj_load_obj_with_callbacks_f(__VA_ARGS__)
+#define tobj_scene_free(...) tobj_scene_free_f(__VA_ARGS__)
+#define tobj_parse_mtl_from_memory(...) tobj_parse_mtl_from_memory_f(__VA_ARGS__)
+#define tobj_material_list_free(...) tobj_material_list_free_f(__VA_ARGS__)
+#define tobj_material_get_param(...) tobj_material_get_param_f(__VA_ARGS__)
+#endif
+
+/* Single fuzz entry (uses the float family internally). */
+TOBJ_API int tobj_fuzz_one(const uint8_t *data, size_t size);
+
+/* Human-readable name for a result code (static storage). */
+TOBJ_API const char *tobj_result_string(tobj_result r);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TINY_OBJ_C_H_ */

--- a/tiny_obj_c_impl.inc
+++ b/tiny_obj_c_impl.inc
@@ -1,0 +1,1944 @@
+/*
+ * tiny_obj_c_impl.inc -- per-precision OBJ parser + scene teardown.
+ *
+ * Included twice from tiny_obj_c.c with (TOBJ_REAL, TOBJ_SUF) = (float, _f)
+ * and (double, _d). Every file-scope name is suffixed via TOBJ_T() so the two
+ * inclusions do not collide in the single translation unit. Do not include
+ * directly.
+ */
+
+/* ----------------------------------------------------------------------- */
+/* builder                                                                 */
+/* ----------------------------------------------------------------------- */
+
+typedef struct TOBJ_T(tobj_builder) {
+  const tobj_allocator *alloc;
+  tobj_arena *arena;
+  tobj_diag *diag;
+  const tobj_load_config *cfg;
+  tobj_caps caps;
+  tobj_result err;
+  size_t line; /* 1-based current line for diagnostics */
+
+  bool triangulate;
+
+  /* attrib temp vectors (reals / structs) */
+  tobj_vec av;   /* vertices xyz */
+  tobj_vec avw;  /* vertex weights (lazy) */
+  tobj_vec avn;  /* normals xyz */
+  tobj_vec avt;  /* texcoords uv */
+  tobj_vec avtw; /* texcoord w (lazy) */
+  tobj_vec acol; /* colors rgb (lazy) */
+  bool color_seen;
+
+  /* materials + name->id map (filled by the .mtl parser) */
+  tobj_vec materials;   /* TOBJ_T(tobj_material) */
+  tobj_vec matmap_key;  /* const char* (interned) */
+  tobj_vec matmap_id;   /* int */
+  tobj_vec mat_unknown; /* tobj_pending_kv */
+
+  /* finalized shapes */
+  tobj_vec shapes; /* TOBJ_T(tobj_shape) */
+
+  /* current shape accumulation */
+  const char *cur_name;
+  bool cur_has_prims;
+  tobj_vec m_idx;    /* tobj_index */
+  tobj_vec m_fv;     /* unsigned face-vertex counts */
+  tobj_vec m_mid;    /* int material ids */
+  tobj_vec m_sg;     /* unsigned smoothing ids */
+  tobj_vec l_idx;    /* tobj_index */
+  tobj_vec l_cnt;    /* int per-line counts */
+  tobj_vec p_idx;    /* tobj_index */
+
+  /* per-face scratch (reused) */
+  tobj_vec corners;  /* tobj_index */
+  tobj_vec ringpos;  /* TOBJ_REAL */
+  tobj_vec tris;     /* uint32_t */
+  tobj_vec tscratch; /* uint8_t */
+
+  /* free-form geometry (only used when cfg->parse_freeform) */
+  tobj_vec ff_vp;      /* reals (global parameter vertices) */
+  int ff_vp_comps;
+  bool ff_present;     /* any free-form element in current shape */
+  bool ff_active;      /* between curv/curv2/surf and end */
+  int ff_kind;         /* 1=curv 2=curv2 3=surf */
+  tobj_cstype ff_cstype;
+  bool ff_rational;
+  int ff_degu, ff_degv;
+  TOBJ_REAL ff_u0, ff_u1, ff_s0, ff_s1, ff_t0, ff_t1;
+  tobj_vec ff_cp_int;  /* int control points (curv: v idx, curv2: vp idx) */
+  tobj_vec ff_cp_idx;  /* tobj_index control points (surf) */
+  tobj_vec ff_knu;     /* reals (parm u) */
+  tobj_vec ff_knv;     /* reals (parm v) */
+  tobj_vec ff_trim;    /* TOBJ_T(tobj_trim_loop) */
+  tobj_vec ff_hole;
+  tobj_vec ff_scrv;
+  tobj_vec sh_curves;   /* TOBJ_T(tobj_curve) */
+  tobj_vec sh_curves2;  /* TOBJ_T(tobj_curve2) */
+  tobj_vec sh_surfaces; /* TOBJ_T(tobj_surface) */
+
+  /* parser state */
+  int cur_material;
+  unsigned cur_smooth;
+
+  /* multithreading pass 2: vertices already parsed; indices resolve against
+   * running counts instead of the (already full) attrib arrays */
+  bool prefilled;
+  size_t run_numv, run_numvt, run_numvn, run_numvp;
+} TOBJ_T(tobj_builder);
+
+/* Counts used for index fixup: running counts in MT pass 2, else live counts. */
+static size_t TOBJ_T(cnt_v)(TOBJ_T(tobj_builder) * b) {
+  return b->prefilled ? b->run_numv : b->av.count / 3u;
+}
+static size_t TOBJ_T(cnt_vt)(TOBJ_T(tobj_builder) * b) {
+  return b->prefilled ? b->run_numvt : b->avt.count / 2u;
+}
+static size_t TOBJ_T(cnt_vn)(TOBJ_T(tobj_builder) * b) {
+  return b->prefilled ? b->run_numvn : b->avn.count / 3u;
+}
+
+static bool TOBJ_T(b_fail)(TOBJ_T(tobj_builder) * b, tobj_result e) {
+  if (b->err == TOBJ_OK) b->err = e;
+  return false;
+}
+
+static void TOBJ_T(b_warn)(TOBJ_T(tobj_builder) * b, const char *msg) {
+  tobj_diag_append(b->diag, b->alloc, TOBJ_SEV_WARNING, b->line, msg);
+}
+
+/* ----------------------------------------------------------------------- */
+/* index fixup (1-based -> 0-based, negative -> relative)                  */
+/* ----------------------------------------------------------------------- */
+
+static bool TOBJ_T(fix_index)(int idx, size_t n, int *out) {
+  if (idx > 0) {
+    *out = idx - 1;
+    return true;
+  }
+  if (idx == 0) {
+    *out = -1;
+    return false; /* zero index: invalid per spec */
+  }
+  long long r = (long long)n + idx;
+  if (r < 0) {
+    *out = -1;
+    return false;
+  }
+  *out = (int)r;
+  return true;
+}
+
+/* Parse one corner "v[/[vt][/vn]]" against explicit counts. Returns true if a
+ * (possibly relative) vertex index was parsed and is in range. */
+static bool TOBJ_T(parse_corner_n)(const char *tok, size_t len, size_t numv,
+                                   size_t numvt, size_t numvn,
+                                   tobj_index *out) {
+  out->vertex_index = -1;
+  out->normal_index = -1;
+  out->texcoord_index = -1;
+
+  tobj_cursor c;
+  tobj_cur_init(&c, tok, len);
+  int vi;
+  if (!tobj_scan_int(&c.p, c.end, &vi)) return false;
+  bool ok = TOBJ_T(fix_index)(vi, numv, &out->vertex_index);
+  if (c.p < c.end && *c.p == '/') {
+    c.p++;
+    if (c.p < c.end && *c.p != '/') {
+      int ti;
+      if (tobj_scan_int(&c.p, c.end, &ti))
+        TOBJ_T(fix_index)(ti, numvt, &out->texcoord_index);
+    }
+    if (c.p < c.end && *c.p == '/') {
+      c.p++;
+      int ni;
+      if (tobj_scan_int(&c.p, c.end, &ni))
+        TOBJ_T(fix_index)(ni, numvn, &out->normal_index);
+    }
+  }
+  return ok;
+}
+
+/* Parse one face/line/point corner using the builder's current counts. */
+static void TOBJ_T(parse_corner)(TOBJ_T(tobj_builder) * b, const char *tok,
+                                 size_t len, tobj_index *out) {
+  bool ok = TOBJ_T(parse_corner_n)(tok, len, TOBJ_T(cnt_v)(b),
+                                   TOBJ_T(cnt_vt)(b), TOBJ_T(cnt_vn)(b), out);
+  if (!ok && out->vertex_index < 0)
+    TOBJ_T(b_warn)(b, "tinyobjc: invalid vertex index in face\n");
+}
+
+/* ----------------------------------------------------------------------- */
+/* optional parallel-array helpers (lazy with backfill)                    */
+/* ----------------------------------------------------------------------- */
+
+static bool TOBJ_T(opt_push)(tobj_vec *v, size_t comps, size_t vidx,
+                             const TOBJ_REAL *vals, const TOBJ_REAL *deflt,
+                             bool present, const tobj_allocator *a) {
+  if (!present && v->count == 0) return true; /* stay empty */
+  /* backfill defaults up to vidx entries */
+  while (v->count / comps < vidx) {
+    if (!tobj_vec_append(v, deflt, comps, a)) return false;
+  }
+  const TOBJ_REAL *src = present ? vals : deflt;
+  return tobj_vec_append(v, src, comps, a);
+}
+
+/* ----------------------------------------------------------------------- */
+/* directive handlers                                                      */
+/* ----------------------------------------------------------------------- */
+
+static bool TOBJ_T(handle_v)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  double nums[8];
+  int n = 0;
+  while (n < 8) {
+    double d;
+    const char *save = c->p;
+    if (!tobj_scan_double(&c->p, c->end, &d)) {
+      c->p = save;
+      break;
+    }
+    nums[n++] = d;
+  }
+  if (n < 3) {
+    TOBJ_T(b_warn)(b, "tinyobjc: 'v' with fewer than 3 components\n");
+    while (n < 3) nums[n++] = 0.0;
+  }
+  if (b->av.count / 3u >= b->caps.vertices) return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+  size_t vidx = b->av.count / 3u;
+  TOBJ_REAL xyz[3] = {(TOBJ_REAL)nums[0], (TOBJ_REAL)nums[1], (TOBJ_REAL)nums[2]};
+  if (!tobj_vec_append(&b->av, xyz, 3, b->alloc)) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+
+  /* weight: only the 4-number form carries a vertex weight */
+  bool has_w = (n == 4);
+  TOBJ_REAL w = has_w ? (TOBJ_REAL)nums[3] : (TOBJ_REAL)1;
+  TOBJ_REAL wdef = (TOBJ_REAL)1;
+  if (!TOBJ_T(opt_push)(&b->avw, 1, vidx, &w, &wdef, has_w, b->alloc))
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+
+  /* color: the 6/7-number form carries r g b */
+  if (b->cfg->store_vertex_colors) {
+    bool has_c = (n >= 6);
+    TOBJ_REAL rgb[3];
+    rgb[0] = has_c ? (TOBJ_REAL)nums[3] : (TOBJ_REAL)1;
+    rgb[1] = has_c ? (TOBJ_REAL)nums[4] : (TOBJ_REAL)1;
+    rgb[2] = has_c ? (TOBJ_REAL)nums[5] : (TOBJ_REAL)1;
+    TOBJ_REAL white[3] = {(TOBJ_REAL)1, (TOBJ_REAL)1, (TOBJ_REAL)1};
+    if (has_c) b->color_seen = true;
+    if (!TOBJ_T(opt_push)(&b->acol, 3, vidx, rgb, white, has_c, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  }
+  return true;
+}
+
+static bool TOBJ_T(handle_vn)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  TOBJ_REAL xyz[3] = {0, 0, 0};
+  double d;
+  for (int i = 0; i < 3; i++)
+    if (tobj_scan_double(&c->p, c->end, &d)) xyz[i] = (TOBJ_REAL)d;
+  if (!tobj_vec_append(&b->avn, xyz, 3, b->alloc)) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  return true;
+}
+
+static bool TOBJ_T(handle_vt)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  double d;
+  TOBJ_REAL uv[2] = {0, 0};
+  int n = 0;
+  for (; n < 2; n++) {
+    if (!tobj_scan_double(&c->p, c->end, &d)) break;
+    uv[n] = (TOBJ_REAL)d;
+  }
+  size_t tidx = b->avt.count / 2u;
+  if (!tobj_vec_append(&b->avt, uv, 2, b->alloc)) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  bool has_w = tobj_scan_double(&c->p, c->end, &d);
+  TOBJ_REAL w = has_w ? (TOBJ_REAL)d : (TOBJ_REAL)0;
+  TOBJ_REAL wdef = (TOBJ_REAL)0;
+  if (!TOBJ_T(opt_push)(&b->avtw, 1, tidx, &w, &wdef, has_w, b->alloc))
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  return true;
+}
+
+/* Append triangulated/raw face corners to the current shape mesh. */
+static bool TOBJ_T(emit_face)(TOBJ_T(tobj_builder) * b, size_t arity) {
+  const tobj_index *corners = (const tobj_index *)b->corners.data;
+  bool do_tri = b->triangulate && arity > 3u;
+
+  if (!do_tri) {
+    if (b->m_idx.count + arity > b->caps.indices)
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+    if (!tobj_vec_append(&b->m_idx, corners, arity, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    unsigned fv = (unsigned)tobj_size_to_int(arity);
+    if (!tobj_vec_append(&b->m_fv, &fv, 1, b->alloc) ||
+        !tobj_vec_append(&b->m_mid, &b->cur_material, 1, b->alloc) ||
+        !tobj_vec_append(&b->m_sg, &b->cur_smooth, 1, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    b->cur_has_prims = true;
+    return true;
+  }
+
+  /* triangulate */
+  size_t numv = TOBJ_T(cnt_v)(b);
+  bool pos_ok = true;
+  for (size_t k = 0; k < arity; k++) {
+    int vi = corners[k].vertex_index;
+    if (vi < 0 || (size_t)vi >= numv) {
+      pos_ok = false;
+      break;
+    }
+  }
+
+  uint32_t ntri = (uint32_t)(arity - 2u);
+  b->tris.count = 0;
+  if (!tobj_vec_reserve(&b->tris, (size_t)ntri * 3u, b->alloc))
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  uint32_t *tri = (uint32_t *)b->tris.data;
+
+  if (pos_ok) {
+    b->ringpos.count = 0;
+    if (!tobj_vec_reserve(&b->ringpos, arity * 3u, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    TOBJ_REAL *rp = (TOBJ_REAL *)b->ringpos.data;
+    const TOBJ_REAL *vsrc = (const TOBJ_REAL *)b->av.data;
+    for (size_t k = 0; k < arity; k++) {
+      size_t vi = (size_t)corners[k].vertex_index;
+      rp[3 * k + 0] = vsrc[3 * vi + 0];
+      rp[3 * k + 1] = vsrc[3 * vi + 1];
+      rp[3 * k + 2] = vsrc[3 * vi + 2];
+    }
+    size_t need_scratch = tobj_tess_scratch_size((uint32_t)arity);
+    if (!tobj_vec_reserve(&b->tscratch, need_scratch, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+
+    TOBJ_T(tobj_tess_desc) desc;
+    tobj_memset(&desc, 0, sizeof desc);
+    desc.points = rp;
+    desc.n = (uint32_t)arity;
+    desc.out_indices = tri;
+    desc.out_cap = ntri * 3u;
+    desc.scratch = b->tscratch.data;
+    desc.scratch_size = need_scratch;
+    tobj_tess_result res;
+    TOBJ_T(tobj_tess_polygon)(&desc, &res);
+    ntri = res.num_triangles;
+    if (res.status == TOBJ_TESS_DEGENERATE_BESTEFFORT)
+      TOBJ_T(b_warn)(b, "tinyobjc: degenerate polygon triangulated best-effort\n");
+  } else {
+    TOBJ_T(b_warn)(b, "tinyobjc: face with invalid vertex index; fan fallback\n");
+    for (uint32_t t = 0; t < ntri; t++) {
+      tri[3 * t + 0] = 0;
+      tri[3 * t + 1] = t + 1;
+      tri[3 * t + 2] = t + 2;
+    }
+  }
+
+  if (b->m_idx.count + (size_t)ntri * 3u > b->caps.indices)
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+  for (uint32_t t = 0; t < ntri; t++) {
+    tobj_index tidx[3];
+    tidx[0] = corners[tri[3 * t + 0]];
+    tidx[1] = corners[tri[3 * t + 1]];
+    tidx[2] = corners[tri[3 * t + 2]];
+    unsigned fv = 3;
+    if (!tobj_vec_append(&b->m_idx, tidx, 3, b->alloc) ||
+        !tobj_vec_append(&b->m_fv, &fv, 1, b->alloc) ||
+        !tobj_vec_append(&b->m_mid, &b->cur_material, 1, b->alloc) ||
+        !tobj_vec_append(&b->m_sg, &b->cur_smooth, 1, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  }
+  b->cur_has_prims = true;
+  return true;
+}
+
+static bool TOBJ_T(handle_f)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  b->corners.count = 0;
+  const char *tok;
+  size_t tlen;
+  size_t arity = 0;
+  while (tobj_next_token(c, &tok, &tlen)) {
+    if (arity >= b->caps.arity) return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+    tobj_index *slot = (tobj_index *)tobj_vec_push(&b->corners, b->alloc);
+    if (!slot) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    TOBJ_T(parse_corner)(b, tok, tlen, slot);
+    arity++;
+  }
+  if (arity < 3) {
+    TOBJ_T(b_warn)(b, "tinyobjc: degenerate face (<3 vertices)\n");
+    return true;
+  }
+  if (b->m_fv.count >= b->caps.faces) return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+  return TOBJ_T(emit_face)(b, arity);
+}
+
+static bool TOBJ_T(handle_l)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  const char *tok;
+  size_t tlen;
+  size_t cnt = 0;
+  size_t start = b->l_idx.count;
+  while (tobj_next_token(c, &tok, &tlen)) {
+    if (cnt >= b->caps.arity) return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+    tobj_index idx;
+    TOBJ_T(parse_corner)(b, tok, tlen, &idx);
+    if (!tobj_vec_append(&b->l_idx, &idx, 1, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    cnt++;
+  }
+  if (cnt < 2) {
+    b->l_idx.count = start; /* roll back */
+    TOBJ_T(b_warn)(b, "tinyobjc: degenerate line (<2 vertices)\n");
+    return true;
+  }
+  int icnt = tobj_size_to_int(cnt);
+  if (!tobj_vec_append(&b->l_cnt, &icnt, 1, b->alloc))
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  b->cur_has_prims = true;
+  return true;
+}
+
+static bool TOBJ_T(handle_p)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  const char *tok;
+  size_t tlen;
+  while (tobj_next_token(c, &tok, &tlen)) {
+    tobj_index idx;
+    TOBJ_T(parse_corner)(b, tok, tlen, &idx);
+    if (!tobj_vec_append(&b->p_idx, &idx, 1, b->alloc))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    b->cur_has_prims = true;
+  }
+  return true;
+}
+
+/* ----------------------------------------------------------------------- */
+/* shape finalize                                                          */
+/* ----------------------------------------------------------------------- */
+
+#define TOBJ_FIN(dst_ptr, dst_cnt, vec, T)                       \
+  do {                                                           \
+    (dst_cnt) = (vec).count;                                     \
+    (dst_ptr) = (T *)tobj_vec_finalize(&(vec), b->arena, 16);    \
+    if ((vec).count && !(dst_ptr)) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC); \
+    (vec).count = 0;                                             \
+  } while (0)
+
+static bool TOBJ_T(ff_finalize_elem)(TOBJ_T(tobj_builder) * b); /* fwd */
+
+static bool TOBJ_T(finalize_shape)(TOBJ_T(tobj_builder) * b) {
+  if (b->ff_active && !TOBJ_T(ff_finalize_elem)(b)) return false;
+  bool has_ff = b->sh_curves.count || b->sh_curves2.count ||
+                b->sh_surfaces.count;
+  if (!b->cur_has_prims && b->m_fv.count == 0 && b->l_cnt.count == 0 &&
+      b->p_idx.count == 0 && !has_ff) {
+    /* nothing to emit, but keep the name for the next group */
+    return true;
+  }
+  if (b->shapes.count >= b->caps.shapes) return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+
+  TOBJ_T(tobj_shape) sh;
+  tobj_memset(&sh, 0, sizeof sh);
+  sh.name = b->cur_name ? b->cur_name : tobj_intern(b->arena, "", 0);
+  if (!sh.name) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+
+  size_t nf;
+  TOBJ_FIN(sh.mesh.indices, sh.mesh.num_indices, b->m_idx, tobj_index);
+  TOBJ_FIN(sh.mesh.num_face_vertices, nf, b->m_fv, unsigned);
+  sh.mesh.num_faces = nf;
+  TOBJ_FIN(sh.mesh.material_ids, nf, b->m_mid, int);
+  TOBJ_FIN(sh.mesh.smoothing_group_ids, nf, b->m_sg, unsigned);
+
+  TOBJ_FIN(sh.lines.indices, sh.lines.num_indices, b->l_idx, tobj_index);
+  TOBJ_FIN(sh.lines.num_line_vertices, sh.lines.num_lines, b->l_cnt, int);
+
+  TOBJ_FIN(sh.points.indices, sh.points.num_indices, b->p_idx, tobj_index);
+
+  /* free-form geometry, if any accumulated for this shape */
+  if (b->sh_curves.count || b->sh_curves2.count || b->sh_surfaces.count) {
+    TOBJ_T(tobj_freeform) *ff = (TOBJ_T(tobj_freeform) *)tobj_arena_alloc(
+        b->arena, sizeof(*ff), 16);
+    if (!ff) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    tobj_memset(ff, 0, sizeof *ff);
+    ff->vp.components = b->ff_vp_comps;
+    ff->vp.uvw.count = b->ff_vp.count;
+    ff->vp.uvw.ptr = (TOBJ_REAL *)tobj_arena_dup(
+        b->arena, b->ff_vp.data, b->ff_vp.count * sizeof(TOBJ_REAL), 16);
+    if (b->ff_vp.count && !ff->vp.uvw.ptr)
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    TOBJ_FIN(ff->curves, ff->num_curves, b->sh_curves, TOBJ_T(tobj_curve));
+    TOBJ_FIN(ff->curves2, ff->num_curves2, b->sh_curves2, TOBJ_T(tobj_curve2));
+    TOBJ_FIN(ff->surfaces, ff->num_surfaces, b->sh_surfaces,
+             TOBJ_T(tobj_surface));
+    sh.freeform = ff;
+  }
+
+  TOBJ_T(tobj_shape) *slot = (TOBJ_T(tobj_shape) *)tobj_vec_push(&b->shapes, b->alloc);
+  if (!slot) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  *slot = sh;
+  b->cur_has_prims = false;
+  return true;
+}
+
+/* Start a new shape group with the given (interned) name. */
+static bool TOBJ_T(new_group)(TOBJ_T(tobj_builder) * b, const char *name) {
+  if (!TOBJ_T(finalize_shape)(b)) return false;
+  b->cur_name = name;
+  return true;
+}
+
+/* ----------------------------------------------------------------------- */
+/* material support                                                        */
+/* ----------------------------------------------------------------------- */
+
+static void TOBJ_T(texopt_init)(TOBJ_T(tobj_texture_option) * t, tobj_arena *ar) {
+  tobj_memset(t, 0, sizeof *t);
+  t->type = TOBJ_TEXTURE_TYPE_NONE;
+  t->sharpness = (TOBJ_REAL)1;
+  t->brightness = (TOBJ_REAL)0;
+  t->contrast = (TOBJ_REAL)1;
+  t->scale[0] = t->scale[1] = t->scale[2] = (TOBJ_REAL)1;
+  t->texture_resolution = -1;
+  t->clamp = false;
+  t->blendu = true;
+  t->blendv = true;
+  t->imfchan = 'm';
+  t->bump_multiplier = (TOBJ_REAL)1;
+  t->colorspace = tobj_intern(ar, "", 0);
+}
+
+static void TOBJ_T(material_init)(TOBJ_T(tobj_material) * m, tobj_arena *ar) {
+  tobj_memset(m, 0, sizeof *m);
+  m->shininess = (TOBJ_REAL)1;
+  m->ior = (TOBJ_REAL)1;
+  m->dissolve = (TOBJ_REAL)1;
+  m->illum = 0;
+  const char *empty = tobj_intern(ar, "", 0);
+  m->name = empty;
+  m->ambient_texname = m->diffuse_texname = m->specular_texname = empty;
+  m->specular_highlight_texname = m->bump_texname = m->displacement_texname = empty;
+  m->alpha_texname = m->reflection_texname = empty;
+  m->roughness_texname = m->metallic_texname = m->sheen_texname = empty;
+  m->emissive_texname = m->normal_texname = empty;
+  TOBJ_T(texopt_init)(&m->ambient_texopt, ar);
+  TOBJ_T(texopt_init)(&m->diffuse_texopt, ar);
+  TOBJ_T(texopt_init)(&m->specular_texopt, ar);
+  TOBJ_T(texopt_init)(&m->specular_highlight_texopt, ar);
+  TOBJ_T(texopt_init)(&m->bump_texopt, ar);
+  TOBJ_T(texopt_init)(&m->displacement_texopt, ar);
+  TOBJ_T(texopt_init)(&m->alpha_texopt, ar);
+  TOBJ_T(texopt_init)(&m->reflection_texopt, ar);
+  TOBJ_T(texopt_init)(&m->roughness_texopt, ar);
+  TOBJ_T(texopt_init)(&m->metallic_texopt, ar);
+  TOBJ_T(texopt_init)(&m->sheen_texopt, ar);
+  TOBJ_T(texopt_init)(&m->emissive_texopt, ar);
+  TOBJ_T(texopt_init)(&m->normal_texopt, ar);
+}
+
+static int TOBJ_T(mat_find)(TOBJ_T(tobj_builder) * b, const char *name,
+                            size_t len) {
+  const char **keys = (const char **)b->matmap_key.data;
+  const int *ids = (const int *)b->matmap_id.data;
+  for (size_t i = 0; i < b->matmap_key.count; i++) {
+    if (tobj_slice_eq(name, len, keys[i])) return ids[i];
+  }
+  return -1;
+}
+
+/* Read up to `n` reals from the cursor into dst (missing left untouched). */
+static void TOBJ_T(read_reals)(tobj_cursor *c, TOBJ_REAL *dst, int n) {
+  double d;
+  for (int i = 0; i < n; i++) {
+    if (!tobj_scan_double(&c->p, c->end, &d)) break;
+    dst[i] = (TOBJ_REAL)d;
+  }
+}
+
+/* Trim leading/trailing spaces of the cursor remainder and intern it. */
+static const char *TOBJ_T(intern_rest)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  const char *p = c->p, *e = c->end;
+  while (p < e && tobj_is_space(*p)) p++;
+  while (e > p && tobj_is_space(e[-1])) e--;
+  return tobj_intern(b->arena, p, (size_t)(e - p));
+}
+
+static bool TOBJ_T(tok_onoff)(const char *t, size_t l, bool *out) {
+  if (tobj_slice_eq(t, l, "on")) {
+    *out = true;
+    return true;
+  }
+  if (tobj_slice_eq(t, l, "off")) {
+    *out = false;
+    return true;
+  }
+  return false;
+}
+
+/* Parse "[-options ...] filename" into texopt (+ interned name). Mirrors the
+ * C++ ParseTextureNameAndOption. The cursor is consumed up to the filename. */
+static const char *TOBJ_T(parse_texopt)(TOBJ_T(tobj_builder) * b, tobj_cursor *c,
+                                        TOBJ_T(tobj_texture_option) * opt) {
+  const char *tok;
+  size_t tl;
+  for (;;) {
+    const char *save = c->p;
+    if (!tobj_next_token(c, &tok, &tl)) {
+      c->p = save;
+      break;
+    }
+    if (tl == 0 || tok[0] != '-') {
+      c->p = save; /* not an option: filename begins here */
+      break;
+    }
+    if (tobj_slice_eq(tok, tl, "-blendu")) {
+      const char *v;
+      size_t vl;
+      if (tobj_next_token(c, &v, &vl)) TOBJ_T(tok_onoff)(v, vl, &opt->blendu);
+    } else if (tobj_slice_eq(tok, tl, "-blendv")) {
+      const char *v;
+      size_t vl;
+      if (tobj_next_token(c, &v, &vl)) TOBJ_T(tok_onoff)(v, vl, &opt->blendv);
+    } else if (tobj_slice_eq(tok, tl, "-clamp")) {
+      const char *v;
+      size_t vl;
+      if (tobj_next_token(c, &v, &vl)) TOBJ_T(tok_onoff)(v, vl, &opt->clamp);
+    } else if (tobj_slice_eq(tok, tl, "-bm")) {
+      TOBJ_T(read_reals)(c, &opt->bump_multiplier, 1);
+    } else if (tobj_slice_eq(tok, tl, "-boost")) {
+      TOBJ_T(read_reals)(c, &opt->sharpness, 1);
+    } else if (tobj_slice_eq(tok, tl, "-o")) {
+      TOBJ_T(read_reals)(c, opt->origin_offset, 3);
+    } else if (tobj_slice_eq(tok, tl, "-s")) {
+      TOBJ_T(read_reals)(c, opt->scale, 3);
+    } else if (tobj_slice_eq(tok, tl, "-t")) {
+      TOBJ_T(read_reals)(c, opt->turbulence, 3);
+    } else if (tobj_slice_eq(tok, tl, "-mm")) {
+      TOBJ_T(read_reals)(c, &opt->brightness, 1);
+      TOBJ_T(read_reals)(c, &opt->contrast, 1);
+    } else if (tobj_slice_eq(tok, tl, "-texres")) {
+      int v = -1;
+      tobj_scan_int(&c->p, c->end, &v);
+      opt->texture_resolution = v;
+    } else if (tobj_slice_eq(tok, tl, "-imfchan")) {
+      const char *v;
+      size_t vl;
+      if (tobj_next_token(c, &v, &vl) && vl >= 1) opt->imfchan = v[0];
+    } else if (tobj_slice_eq(tok, tl, "-type")) {
+      const char *v;
+      size_t vl;
+      if (tobj_next_token(c, &v, &vl)) {
+        if (tobj_slice_eq(v, vl, "sphere"))
+          opt->type = TOBJ_TEXTURE_TYPE_SPHERE;
+        else if (tobj_slice_eq(v, vl, "cube_top"))
+          opt->type = TOBJ_TEXTURE_TYPE_CUBE_TOP;
+        else if (tobj_slice_eq(v, vl, "cube_bottom"))
+          opt->type = TOBJ_TEXTURE_TYPE_CUBE_BOTTOM;
+        else if (tobj_slice_eq(v, vl, "cube_front"))
+          opt->type = TOBJ_TEXTURE_TYPE_CUBE_FRONT;
+        else if (tobj_slice_eq(v, vl, "cube_back"))
+          opt->type = TOBJ_TEXTURE_TYPE_CUBE_BACK;
+        else if (tobj_slice_eq(v, vl, "cube_left"))
+          opt->type = TOBJ_TEXTURE_TYPE_CUBE_LEFT;
+        else if (tobj_slice_eq(v, vl, "cube_right"))
+          opt->type = TOBJ_TEXTURE_TYPE_CUBE_RIGHT;
+      }
+    } else if (tobj_slice_eq(tok, tl, "-colorspace")) {
+      const char *v;
+      size_t vl;
+      if (tobj_next_token(c, &v, &vl))
+        opt->colorspace = tobj_intern(b->arena, v, vl);
+    } else {
+      /* unknown option flag: skip just the flag token */
+    }
+  }
+  return TOBJ_T(intern_rest)(b, c);
+}
+
+/* Record an unrecognized "key value" .mtl line for material `mi`. */
+static bool TOBJ_T(push_unknown)(TOBJ_T(tobj_builder) * b, size_t mi,
+                                 const char *key, size_t keylen,
+                                 tobj_cursor *c) {
+  tobj_pending_kv *kv = (tobj_pending_kv *)tobj_vec_push(&b->mat_unknown, b->alloc);
+  if (!kv) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  kv->mat_index = mi;
+  kv->key = tobj_intern(b->arena, key, keylen);
+  kv->value = TOBJ_T(intern_rest)(b, c);
+  if (!kv->key || !kv->value) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  return true;
+}
+
+/* If map_Kd was given but Kd was not, default diffuse to 0.6 (C++ parity). */
+static void TOBJ_T(apply_kd_default)(TOBJ_T(tobj_material) * m, bool kd_seen) {
+  if (!kd_seen && m->diffuse_texname && m->diffuse_texname[0] != '\0') {
+    m->diffuse[0] = m->diffuse[1] = m->diffuse[2] = (TOBJ_REAL)0.6;
+  }
+}
+
+/* Full .mtl parser. */
+static bool TOBJ_T(parse_mtl_buffer)(TOBJ_T(tobj_builder) * b,
+                                     const uint8_t *data, size_t len) {
+  tobj_vec lines;
+  tobj_vec_init(&lines, sizeof(tobj_line));
+  if (!tobj_build_line_index(data, len, &lines, b->alloc)) {
+    tobj_vec_free(&lines, b->alloc);
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  }
+  const char *base = (const char *)data;
+  int cur = -1;
+  bool kd_seen = false;
+  for (size_t i = 0; i < lines.count && b->err == TOBJ_OK; i++) {
+    tobj_line *ln = (tobj_line *)tobj_vec_at(&lines, i);
+    if (ln->len > b->caps.line_bytes) continue;
+    tobj_cursor c;
+    tobj_cur_init(&c, base + ln->pos, ln->len);
+    const char *tok;
+    size_t tl;
+    if (!tobj_next_token(&c, &tok, &tl)) continue;
+    if (tl && tok[0] == '#') continue;
+
+    if (tobj_slice_eq(tok, tl, "newmtl")) {
+      if (cur >= 0)
+        TOBJ_T(apply_kd_default)(
+            (TOBJ_T(tobj_material) *)tobj_vec_at(&b->materials, (size_t)cur),
+            kd_seen);
+      if (b->materials.count >= b->caps.materials) {
+        TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+        break;
+      }
+      TOBJ_T(tobj_material) *m =
+          (TOBJ_T(tobj_material) *)tobj_vec_push(&b->materials, b->alloc);
+      if (!m) {
+        TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+        break;
+      }
+      TOBJ_T(material_init)(m, b->arena);
+      m->name = TOBJ_T(intern_rest)(b, &c);
+      cur = (int)(b->materials.count - 1);
+      kd_seen = false;
+      const char **k = (const char **)tobj_vec_push(&b->matmap_key, b->alloc);
+      int *id = (int *)tobj_vec_push(&b->matmap_id, b->alloc);
+      if (!k || !id) {
+        TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+        break;
+      }
+      *k = m->name;
+      *id = cur;
+      continue;
+    }
+    if (cur < 0) continue;
+    TOBJ_T(tobj_material) *m =
+        (TOBJ_T(tobj_material) *)tobj_vec_at(&b->materials, (size_t)cur);
+
+    if (tobj_slice_eq(tok, tl, "Ka")) {
+      TOBJ_T(read_reals)(&c, m->ambient, 3);
+    } else if (tobj_slice_eq(tok, tl, "Kd")) {
+      TOBJ_T(read_reals)(&c, m->diffuse, 3);
+      kd_seen = true;
+    } else if (tobj_slice_eq(tok, tl, "Ks")) {
+      TOBJ_T(read_reals)(&c, m->specular, 3);
+    } else if (tobj_slice_eq(tok, tl, "Ke")) {
+      TOBJ_T(read_reals)(&c, m->emission, 3);
+    } else if (tobj_slice_eq(tok, tl, "Kt") || tobj_slice_eq(tok, tl, "Tf")) {
+      TOBJ_T(read_reals)(&c, m->transmittance, 3);
+    } else if (tobj_slice_eq(tok, tl, "Ns")) {
+      TOBJ_T(read_reals)(&c, &m->shininess, 1);
+    } else if (tobj_slice_eq(tok, tl, "Ni")) {
+      TOBJ_T(read_reals)(&c, &m->ior, 1);
+    } else if (tobj_slice_eq(tok, tl, "d")) {
+      TOBJ_T(read_reals)(&c, &m->dissolve, 1);
+    } else if (tobj_slice_eq(tok, tl, "Tr")) {
+      TOBJ_REAL tr = 0;
+      TOBJ_T(read_reals)(&c, &tr, 1);
+      m->dissolve = (TOBJ_REAL)1 - tr;
+    } else if (tobj_slice_eq(tok, tl, "illum")) {
+      int v = 0;
+      tobj_scan_int(&c.p, c.end, &v);
+      m->illum = v;
+    } else if (tobj_slice_eq(tok, tl, "Pr")) {
+      TOBJ_T(read_reals)(&c, &m->roughness, 1);
+    } else if (tobj_slice_eq(tok, tl, "Pm")) {
+      TOBJ_T(read_reals)(&c, &m->metallic, 1);
+    } else if (tobj_slice_eq(tok, tl, "Ps")) {
+      TOBJ_T(read_reals)(&c, &m->sheen, 1);
+    } else if (tobj_slice_eq(tok, tl, "Pc")) {
+      TOBJ_T(read_reals)(&c, &m->clearcoat_thickness, 1);
+    } else if (tobj_slice_eq(tok, tl, "Pcr")) {
+      TOBJ_T(read_reals)(&c, &m->clearcoat_roughness, 1);
+    } else if (tobj_slice_eq(tok, tl, "aniso")) {
+      TOBJ_T(read_reals)(&c, &m->anisotropy, 1);
+    } else if (tobj_slice_eq(tok, tl, "anisor")) {
+      TOBJ_T(read_reals)(&c, &m->anisotropy_rotation, 1);
+    } else if (tobj_slice_eq(tok, tl, "map_Ka")) {
+      m->ambient_texname = TOBJ_T(parse_texopt)(b, &c, &m->ambient_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Kd")) {
+      m->diffuse_texname = TOBJ_T(parse_texopt)(b, &c, &m->diffuse_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Ks")) {
+      m->specular_texname = TOBJ_T(parse_texopt)(b, &c, &m->specular_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Ns")) {
+      m->specular_highlight_texname =
+          TOBJ_T(parse_texopt)(b, &c, &m->specular_highlight_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_d")) {
+      m->alpha_texname = TOBJ_T(parse_texopt)(b, &c, &m->alpha_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_bump") ||
+               tobj_slice_eq(tok, tl, "map_Bump") ||
+               tobj_slice_eq(tok, tl, "bump")) {
+      m->bump_texopt.imfchan = 'l';
+      m->bump_texname = TOBJ_T(parse_texopt)(b, &c, &m->bump_texopt);
+    } else if (tobj_slice_eq(tok, tl, "disp")) {
+      m->displacement_texname =
+          TOBJ_T(parse_texopt)(b, &c, &m->displacement_texopt);
+    } else if (tobj_slice_eq(tok, tl, "refl")) {
+      m->reflection_texname = TOBJ_T(parse_texopt)(b, &c, &m->reflection_texopt);
+    } else if (tobj_slice_eq(tok, tl, "norm")) {
+      m->normal_texname = TOBJ_T(parse_texopt)(b, &c, &m->normal_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Pr")) {
+      m->roughness_texname = TOBJ_T(parse_texopt)(b, &c, &m->roughness_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Pm")) {
+      m->metallic_texname = TOBJ_T(parse_texopt)(b, &c, &m->metallic_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Ps")) {
+      m->sheen_texname = TOBJ_T(parse_texopt)(b, &c, &m->sheen_texopt);
+    } else if (tobj_slice_eq(tok, tl, "map_Ke")) {
+      m->emissive_texname = TOBJ_T(parse_texopt)(b, &c, &m->emissive_texopt);
+    } else {
+      /* unknown parameter: store key -> rest of line */
+      if (!TOBJ_T(push_unknown)(b, (size_t)cur, tok, tl, &c)) break;
+    }
+  }
+
+  if (cur >= 0)
+    TOBJ_T(apply_kd_default)(
+        (TOBJ_T(tobj_material) *)tobj_vec_at(&b->materials, (size_t)cur),
+        kd_seen);
+  tobj_vec_free(&lines, b->alloc);
+  return b->err == TOBJ_OK;
+}
+
+static bool TOBJ_T(handle_mtllib)(TOBJ_T(tobj_builder) * b, tobj_cursor *c) {
+  if (!b->cfg->mtl_resolver) {
+    TOBJ_T(b_warn)(b, "tinyobjc: mtllib present but no material resolver\n");
+    return true;
+  }
+  const char *tok;
+  size_t tl;
+  while (tobj_next_token(c, &tok, &tl)) {
+    char *name = (char *)tobj_arena_alloc(b->arena, tl + 1, 1);
+    if (!name) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    tobj_memcpy(name, tok, tl);
+    name[tl] = '\0';
+    tobj_mtl_source src;
+    tobj_memset(&src, 0, sizeof src);
+    tobj_result r =
+        b->cfg->mtl_resolver(b->cfg->mtl_resolver_user_data, name, &src);
+    if (r != TOBJ_OK) {
+      TOBJ_T(b_warn)(b, "tinyobjc: failed to resolve mtllib\n");
+      continue;
+    }
+    TOBJ_T(parse_mtl_buffer)(b, src.data, src.len);
+    if (src.release) src.release(src.release_ud, src.data, src.len);
+    if (b->err != TOBJ_OK) return false;
+  }
+  return true;
+}
+
+/* ----------------------------------------------------------------------- */
+/* free-form geometry (parse & retain; no NURBS evaluation)                */
+/* ----------------------------------------------------------------------- */
+
+static void TOBJ_T(ff_reset_elem)(TOBJ_T(tobj_builder) * b) {
+  b->ff_active = false;
+  b->ff_kind = 0;
+  b->ff_cp_int.count = 0;
+  b->ff_cp_idx.count = 0;
+  b->ff_knu.count = 0;
+  b->ff_knv.count = 0;
+  b->ff_trim.count = 0;
+  b->ff_hole.count = 0;
+  b->ff_scrv.count = 0;
+}
+
+static bool TOBJ_T(ff_finalize_elem)(TOBJ_T(tobj_builder) * b) {
+  if (!b->ff_active) return true;
+  if (b->ff_kind == 1) { /* curv */
+    TOBJ_T(tobj_curve) *cv =
+        (TOBJ_T(tobj_curve) *)tobj_vec_push(&b->sh_curves, b->alloc);
+    if (!cv) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    cv->type = b->ff_cstype;
+    cv->rational = b->ff_rational;
+    cv->degree = b->ff_degu;
+    cv->u0 = b->ff_u0;
+    cv->u1 = b->ff_u1;
+    cv->num_control_points = b->ff_cp_int.count;
+    cv->control_points = (int *)tobj_vec_finalize(&b->ff_cp_int, b->arena, 16);
+    cv->num_knots = b->ff_knu.count;
+    cv->knots = (TOBJ_REAL *)tobj_vec_finalize(&b->ff_knu, b->arena, 16);
+    if ((cv->num_control_points && !cv->control_points) ||
+        (cv->num_knots && !cv->knots))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  } else if (b->ff_kind == 2) { /* curv2 */
+    TOBJ_T(tobj_curve2) *cv =
+        (TOBJ_T(tobj_curve2) *)tobj_vec_push(&b->sh_curves2, b->alloc);
+    if (!cv) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    cv->type = b->ff_cstype;
+    cv->rational = b->ff_rational;
+    cv->degree = b->ff_degu;
+    cv->num_control_points = b->ff_cp_int.count;
+    cv->control_points = (int *)tobj_vec_finalize(&b->ff_cp_int, b->arena, 16);
+    cv->num_knots = b->ff_knu.count;
+    cv->knots = (TOBJ_REAL *)tobj_vec_finalize(&b->ff_knu, b->arena, 16);
+    if ((cv->num_control_points && !cv->control_points) ||
+        (cv->num_knots && !cv->knots))
+      return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  } else if (b->ff_kind == 3) { /* surf */
+    TOBJ_T(tobj_surface) *sf =
+        (TOBJ_T(tobj_surface) *)tobj_vec_push(&b->sh_surfaces, b->alloc);
+    if (!sf) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    sf->type = b->ff_cstype;
+    sf->rational = b->ff_rational;
+    sf->degu = b->ff_degu;
+    sf->degv = b->ff_degv;
+    sf->s0 = b->ff_s0;
+    sf->s1 = b->ff_s1;
+    sf->t0 = b->ff_t0;
+    sf->t1 = b->ff_t1;
+    sf->num_control_points = b->ff_cp_idx.count;
+    sf->control_points =
+        (tobj_index *)tobj_vec_finalize(&b->ff_cp_idx, b->arena, 16);
+    sf->num_knots_u = b->ff_knu.count;
+    sf->knots_u = (TOBJ_REAL *)tobj_vec_finalize(&b->ff_knu, b->arena, 16);
+    sf->num_knots_v = b->ff_knv.count;
+    sf->knots_v = (TOBJ_REAL *)tobj_vec_finalize(&b->ff_knv, b->arena, 16);
+    sf->num_trims = b->ff_trim.count;
+    sf->trims = (TOBJ_T(tobj_trim_loop) *)tobj_vec_finalize(&b->ff_trim,
+                                                            b->arena, 16);
+    sf->num_holes = b->ff_hole.count;
+    sf->holes = (TOBJ_T(tobj_trim_loop) *)tobj_vec_finalize(&b->ff_hole,
+                                                            b->arena, 16);
+    sf->num_scrvs = b->ff_scrv.count;
+    sf->scrvs = (TOBJ_T(tobj_trim_loop) *)tobj_vec_finalize(&b->ff_scrv,
+                                                            b->arena, 16);
+  }
+  b->ff_present = true;
+  TOBJ_T(ff_reset_elem)(b);
+  return true;
+}
+
+static void TOBJ_T(ff_loops)(TOBJ_T(tobj_builder) * b, tobj_cursor *c,
+                             tobj_vec *dst) {
+  double u0, u1;
+  int idx;
+  while (tobj_scan_double(&c->p, c->end, &u0)) {
+    if (!tobj_scan_double(&c->p, c->end, &u1)) break;
+    if (!tobj_scan_int(&c->p, c->end, &idx)) break;
+    TOBJ_T(tobj_trim_loop) *t =
+        (TOBJ_T(tobj_trim_loop) *)tobj_vec_push(dst, b->alloc);
+    if (!t) {
+      TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+      return;
+    }
+    t->u0 = (TOBJ_REAL)u0;
+    t->u1 = (TOBJ_REAL)u1;
+    t->curve2_index = idx;
+  }
+}
+
+static bool TOBJ_T(handle_freeform)(TOBJ_T(tobj_builder) * b, const char *tok,
+                                    size_t tl, tobj_cursor *c) {
+  if (tobj_slice_eq(tok, tl, "vp")) {
+    double d;
+    int n = 0;
+    TOBJ_REAL uvw[3] = {0, 0, 0};
+    for (; n < 3; n++) {
+      if (!tobj_scan_double(&c->p, c->end, &d)) break;
+      uvw[n] = (TOBJ_REAL)d;
+    }
+    if (n < 1) return true;
+    if (n > b->ff_vp_comps) b->ff_vp_comps = n;
+    return tobj_vec_append(&b->ff_vp, uvw, (size_t)n, b->alloc)
+               ? true
+               : TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  }
+  if (tobj_slice_eq(tok, tl, "cstype")) {
+    const char *t2;
+    size_t l2;
+    b->ff_rational = false;
+    b->ff_cstype = TOBJ_CSTYPE_NONE;
+    while (tobj_next_token(c, &t2, &l2)) {
+      if (tobj_slice_eq(t2, l2, "rat"))
+        b->ff_rational = true;
+      else if (tobj_slice_eq(t2, l2, "bmatrix"))
+        b->ff_cstype = TOBJ_CSTYPE_BMATRIX;
+      else if (tobj_slice_eq(t2, l2, "bezier"))
+        b->ff_cstype = TOBJ_CSTYPE_BEZIER;
+      else if (tobj_slice_eq(t2, l2, "bspline"))
+        b->ff_cstype = TOBJ_CSTYPE_BSPLINE;
+      else if (tobj_slice_eq(t2, l2, "cardinal"))
+        b->ff_cstype = TOBJ_CSTYPE_CARDINAL;
+      else if (tobj_slice_eq(t2, l2, "taylor"))
+        b->ff_cstype = TOBJ_CSTYPE_TAYLOR;
+    }
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "deg")) {
+    int du = 0, dv = 0;
+    if (tobj_scan_int(&c->p, c->end, &du)) b->ff_degu = du;
+    if (tobj_scan_int(&c->p, c->end, &dv)) b->ff_degv = dv;
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "curv")) {
+    TOBJ_T(ff_reset_elem)(b);
+    b->ff_active = true;
+    b->ff_kind = 1;
+    double a, bb;
+    b->ff_u0 = tobj_scan_double(&c->p, c->end, &a) ? (TOBJ_REAL)a : (TOBJ_REAL)0;
+    b->ff_u1 = tobj_scan_double(&c->p, c->end, &bb) ? (TOBJ_REAL)bb : (TOBJ_REAL)0;
+    int vi;
+    size_t numv = TOBJ_T(cnt_v)(b);
+    while (tobj_scan_int(&c->p, c->end, &vi)) {
+      int r;
+      TOBJ_T(fix_index)(vi, numv, &r);
+      if (!tobj_vec_append(&b->ff_cp_int, &r, 1, b->alloc))
+        return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    }
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "curv2")) {
+    TOBJ_T(ff_reset_elem)(b);
+    b->ff_active = true;
+    b->ff_kind = 2;
+    int vi;
+    size_t numvp = b->prefilled
+                       ? b->run_numvp
+                       : (b->ff_vp_comps ? b->ff_vp.count / (size_t)b->ff_vp_comps
+                                         : 0);
+    while (tobj_scan_int(&c->p, c->end, &vi)) {
+      int r;
+      TOBJ_T(fix_index)(vi, numvp, &r);
+      if (!tobj_vec_append(&b->ff_cp_int, &r, 1, b->alloc))
+        return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    }
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "surf")) {
+    TOBJ_T(ff_reset_elem)(b);
+    b->ff_active = true;
+    b->ff_kind = 3;
+    double s0, s1, t0, t1;
+    b->ff_s0 = tobj_scan_double(&c->p, c->end, &s0) ? (TOBJ_REAL)s0 : 0;
+    b->ff_s1 = tobj_scan_double(&c->p, c->end, &s1) ? (TOBJ_REAL)s1 : 0;
+    b->ff_t0 = tobj_scan_double(&c->p, c->end, &t0) ? (TOBJ_REAL)t0 : 0;
+    b->ff_t1 = tobj_scan_double(&c->p, c->end, &t1) ? (TOBJ_REAL)t1 : 0;
+    const char *t2;
+    size_t l2;
+    while (tobj_next_token(c, &t2, &l2)) {
+      tobj_index idx;
+      TOBJ_T(parse_corner_n)(t2, l2, TOBJ_T(cnt_v)(b), TOBJ_T(cnt_vt)(b),
+                             TOBJ_T(cnt_vn)(b), &idx);
+      if (!tobj_vec_append(&b->ff_cp_idx, &idx, 1, b->alloc))
+        return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    }
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "parm")) {
+    const char *t2;
+    size_t l2;
+    if (!tobj_next_token(c, &t2, &l2)) return true;
+    tobj_vec *dst = tobj_slice_eq(t2, l2, "v") ? &b->ff_knv : &b->ff_knu;
+    double d;
+    while (tobj_scan_double(&c->p, c->end, &d)) {
+      TOBJ_REAL r = (TOBJ_REAL)d;
+      if (!tobj_vec_append(dst, &r, 1, b->alloc))
+        return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    }
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "trim")) {
+    TOBJ_T(ff_loops)(b, c, &b->ff_trim);
+    return b->err == TOBJ_OK;
+  }
+  if (tobj_slice_eq(tok, tl, "hole")) {
+    TOBJ_T(ff_loops)(b, c, &b->ff_hole);
+    return b->err == TOBJ_OK;
+  }
+  if (tobj_slice_eq(tok, tl, "scrv")) {
+    TOBJ_T(ff_loops)(b, c, &b->ff_scrv);
+    return b->err == TOBJ_OK;
+  }
+  if (tobj_slice_eq(tok, tl, "end")) {
+    return TOBJ_T(ff_finalize_elem)(b);
+  }
+  /* sp / con / bmat / step etc.: recognized but not retained */
+  return true;
+}
+
+/* ----------------------------------------------------------------------- */
+/* line dispatch                                                           */
+/* ----------------------------------------------------------------------- */
+
+static bool TOBJ_T(dispatch_line)(TOBJ_T(tobj_builder) * b, const char *p,
+                                  size_t len) {
+  if (len > b->caps.line_bytes) return TOBJ_T(b_fail)(b, TOBJ_ERR_LIMIT_EXCEEDED);
+  tobj_cursor c;
+  tobj_cur_init(&c, p, len);
+  const char *tok;
+  size_t tl;
+  if (!tobj_next_token(&c, &tok, &tl)) return true;
+  if (tok[0] == '#') return true;
+
+  /* In MT pass 2 the vertex data is already parsed; just advance the running
+   * counts used for relative-index resolution. */
+  if (b->prefilled) {
+    if (tobj_slice_eq(tok, tl, "v")) {
+      b->run_numv++;
+      return true;
+    }
+    if (tobj_slice_eq(tok, tl, "vn")) {
+      b->run_numvn++;
+      return true;
+    }
+    if (tobj_slice_eq(tok, tl, "vt")) {
+      b->run_numvt++;
+      return true;
+    }
+    if (tobj_slice_eq(tok, tl, "vp")) {
+      b->run_numvp++;
+      return true;
+    }
+  }
+
+  if (tobj_slice_eq(tok, tl, "v")) return TOBJ_T(handle_v)(b, &c);
+  if (tobj_slice_eq(tok, tl, "vn")) return TOBJ_T(handle_vn)(b, &c);
+  if (tobj_slice_eq(tok, tl, "vt")) return TOBJ_T(handle_vt)(b, &c);
+  if (tobj_slice_eq(tok, tl, "f")) return TOBJ_T(handle_f)(b, &c);
+  if (tobj_slice_eq(tok, tl, "l")) return TOBJ_T(handle_l)(b, &c);
+  if (tobj_slice_eq(tok, tl, "p")) return TOBJ_T(handle_p)(b, &c);
+  if (tobj_slice_eq(tok, tl, "g") || tobj_slice_eq(tok, tl, "o")) {
+    const char *name = TOBJ_T(intern_rest)(b, &c);
+    if (!name) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    return TOBJ_T(new_group)(b, name);
+  }
+  if (tobj_slice_eq(tok, tl, "s")) {
+    const char *st;
+    size_t sl;
+    if (tobj_next_token(&c, &st, &sl)) {
+      if (tobj_slice_eq(st, sl, "off")) {
+        b->cur_smooth = 0;
+      } else {
+        const char *q = st;
+        int v = 0;
+        tobj_scan_int(&q, st + sl, &v);
+        b->cur_smooth = v > 0 ? (unsigned)v : 0u;
+      }
+    }
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "usemtl")) {
+    const char *name = c.p;
+    while (name < c.end && tobj_is_space(*name)) name++;
+    const char *e = c.end;
+    while (e > name && tobj_is_space(e[-1])) e--;
+    int id = TOBJ_T(mat_find)(b, name, (size_t)(e - name));
+    if (id < 0) TOBJ_T(b_warn)(b, "tinyobjc: usemtl references unknown material\n");
+    b->cur_material = id;
+    return true;
+  }
+  if (tobj_slice_eq(tok, tl, "mtllib")) return TOBJ_T(handle_mtllib)(b, &c);
+  if (b->cfg->parse_freeform) return TOBJ_T(handle_freeform)(b, tok, tl, &c);
+  /* unrecognized directive: silently skipped */
+  return true;
+}
+
+/* ----------------------------------------------------------------------- */
+/* public entry points                                                     */
+/* ----------------------------------------------------------------------- */
+
+/* Group pending unknown params by material, sort by key, attach to materials. */
+static bool TOBJ_T(finalize_unknowns)(TOBJ_T(tobj_builder) * b) {
+  if (b->mat_unknown.count == 0) return true;
+  const tobj_pending_kv *pend = (const tobj_pending_kv *)b->mat_unknown.data;
+  for (size_t mi = 0; mi < b->materials.count; mi++) {
+    size_t cnt = 0;
+    for (size_t j = 0; j < b->mat_unknown.count; j++)
+      if (pend[j].mat_index == mi) cnt++;
+    if (cnt == 0) continue;
+    tobj_kv *arr = (tobj_kv *)tobj_arena_alloc(b->arena, cnt * sizeof(tobj_kv),
+                                               16);
+    if (!arr) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+    size_t w = 0;
+    for (size_t j = 0; j < b->mat_unknown.count; j++) {
+      if (pend[j].mat_index != mi) continue;
+      /* stable insertion sort by key; equal keys keep insertion order */
+      size_t pos = w;
+      while (pos > 0 && tobj_strcmp(arr[pos - 1].key, pend[j].key) > 0) {
+        arr[pos] = arr[pos - 1];
+        pos--;
+      }
+      arr[pos].key = pend[j].key;
+      arr[pos].value = pend[j].value;
+      w++;
+    }
+    TOBJ_T(tobj_material) *m =
+        (TOBJ_T(tobj_material) *)tobj_vec_at(&b->materials, mi);
+    m->unknown_params = arr;
+    m->num_unknown_params = w;
+  }
+  return true;
+}
+
+static void TOBJ_T(builder_init)(TOBJ_T(tobj_builder) * b) {
+  tobj_vec_init(&b->av, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->avw, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->avn, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->avt, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->avtw, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->acol, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->materials, sizeof(TOBJ_T(tobj_material)));
+  tobj_vec_init(&b->matmap_key, sizeof(const char *));
+  tobj_vec_init(&b->matmap_id, sizeof(int));
+  tobj_vec_init(&b->mat_unknown, sizeof(tobj_pending_kv));
+  tobj_vec_init(&b->shapes, sizeof(TOBJ_T(tobj_shape)));
+  tobj_vec_init(&b->m_idx, sizeof(tobj_index));
+  tobj_vec_init(&b->m_fv, sizeof(unsigned));
+  tobj_vec_init(&b->m_mid, sizeof(int));
+  tobj_vec_init(&b->m_sg, sizeof(unsigned));
+  tobj_vec_init(&b->l_idx, sizeof(tobj_index));
+  tobj_vec_init(&b->l_cnt, sizeof(int));
+  tobj_vec_init(&b->p_idx, sizeof(tobj_index));
+  tobj_vec_init(&b->corners, sizeof(tobj_index));
+  tobj_vec_init(&b->ringpos, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->tris, sizeof(uint32_t));
+  tobj_vec_init(&b->tscratch, 1);
+  tobj_vec_init(&b->ff_vp, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->ff_cp_int, sizeof(int));
+  tobj_vec_init(&b->ff_cp_idx, sizeof(tobj_index));
+  tobj_vec_init(&b->ff_knu, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->ff_knv, sizeof(TOBJ_REAL));
+  tobj_vec_init(&b->ff_trim, sizeof(TOBJ_T(tobj_trim_loop)));
+  tobj_vec_init(&b->ff_hole, sizeof(TOBJ_T(tobj_trim_loop)));
+  tobj_vec_init(&b->ff_scrv, sizeof(TOBJ_T(tobj_trim_loop)));
+  tobj_vec_init(&b->sh_curves, sizeof(TOBJ_T(tobj_curve)));
+  tobj_vec_init(&b->sh_curves2, sizeof(TOBJ_T(tobj_curve2)));
+  tobj_vec_init(&b->sh_surfaces, sizeof(TOBJ_T(tobj_surface)));
+  b->ff_degu = 0;
+  b->ff_degv = 0;
+}
+
+static void TOBJ_T(builder_dispose)(TOBJ_T(tobj_builder) * b) {
+  const tobj_allocator *a = b->alloc;
+  tobj_vec_free(&b->av, a);
+  tobj_vec_free(&b->avw, a);
+  tobj_vec_free(&b->avn, a);
+  tobj_vec_free(&b->avt, a);
+  tobj_vec_free(&b->avtw, a);
+  tobj_vec_free(&b->acol, a);
+  tobj_vec_free(&b->materials, a);
+  tobj_vec_free(&b->matmap_key, a);
+  tobj_vec_free(&b->matmap_id, a);
+  tobj_vec_free(&b->mat_unknown, a);
+  tobj_vec_free(&b->shapes, a);
+  tobj_vec_free(&b->m_idx, a);
+  tobj_vec_free(&b->m_fv, a);
+  tobj_vec_free(&b->m_mid, a);
+  tobj_vec_free(&b->m_sg, a);
+  tobj_vec_free(&b->l_idx, a);
+  tobj_vec_free(&b->l_cnt, a);
+  tobj_vec_free(&b->p_idx, a);
+  tobj_vec_free(&b->corners, a);
+  tobj_vec_free(&b->ringpos, a);
+  tobj_vec_free(&b->tris, a);
+  tobj_vec_free(&b->tscratch, a);
+  tobj_vec_free(&b->ff_vp, a);
+  tobj_vec_free(&b->ff_cp_int, a);
+  tobj_vec_free(&b->ff_cp_idx, a);
+  tobj_vec_free(&b->ff_knu, a);
+  tobj_vec_free(&b->ff_knv, a);
+  tobj_vec_free(&b->ff_trim, a);
+  tobj_vec_free(&b->ff_hole, a);
+  tobj_vec_free(&b->ff_scrv, a);
+  tobj_vec_free(&b->sh_curves, a);
+  tobj_vec_free(&b->sh_curves2, a);
+  tobj_vec_free(&b->sh_surfaces, a);
+}
+
+void TOBJ_T(tobj_scene_free)(TOBJ_T(tobj_scene) * s) {
+  if (!s) return;
+  if (s->arena) {
+    tobj_arena *ar = (tobj_arena *)s->arena;
+    tobj_allocator a = s->allocator;
+    tobj_arena_destroy(ar);
+    tobj_free(&a, ar, sizeof(tobj_arena));
+  }
+  tobj_memset(s, 0, sizeof *s);
+}
+
+const char *TOBJ_T(tobj_material_get_param)(const TOBJ_T(tobj_material) * m,
+                                            const char *key) {
+  if (!m || !key) return NULL;
+  size_t lo = 0, hi = m->num_unknown_params;
+  while (lo < hi) {
+    size_t mid = lo + (hi - lo) / 2;
+    const char *k = m->unknown_params[mid].key;
+    /* strcmp without libc */
+    size_t i = 0;
+    int cmp = 0;
+    for (;; i++) {
+      unsigned char a = (unsigned char)k[i], bb = (unsigned char)key[i];
+      if (a != bb) {
+        cmp = (int)a - (int)bb;
+        break;
+      }
+      if (!a) break;
+    }
+    if (cmp == 0) return m->unknown_params[mid].value;
+    if (cmp < 0)
+      lo = mid + 1;
+    else
+      hi = mid;
+  }
+  return NULL;
+}
+
+#ifdef TOBJ_ENABLE_MULTITHREADING
+/* Per-thread vertex-parse output (MT pass 1). */
+typedef struct TOBJ_T(tobj_tls) {
+  const char *base;
+  const tobj_line *lines;
+  size_t lo, hi;
+  const tobj_allocator *alloc;
+  bool store_colors;
+  bool parse_vp;
+  bool oom;
+  tobj_vec lv, lvw, lvw_has, lcol, lcol_has, lvn, lvt, lvtw, lvtw_has, lvp;
+  int vp_comps;
+} TOBJ_T(tobj_tls);
+
+static void TOBJ_T(mt_worker)(void *arg) {
+  TOBJ_T(tobj_tls) *w = (TOBJ_T(tobj_tls) *)arg;
+  const tobj_allocator *a = w->alloc;
+  for (size_t i = w->lo; i < w->hi && !w->oom; i++) {
+    const tobj_line *ln = &w->lines[i];
+    tobj_cursor c;
+    tobj_cur_init(&c, w->base + ln->pos, ln->len);
+    const char *tok;
+    size_t tl;
+    if (!tobj_next_token(&c, &tok, &tl)) continue;
+    if (tobj_slice_eq(tok, tl, "v")) {
+      double nums[8];
+      int n = 0;
+      while (n < 8) {
+        double d;
+        const char *s = c.p;
+        if (!tobj_scan_double(&c.p, c.end, &d)) {
+          c.p = s;
+          break;
+        }
+        nums[n++] = d;
+      }
+      while (n < 3) nums[n++] = 0.0;
+      TOBJ_REAL xyz[3] = {(TOBJ_REAL)nums[0], (TOBJ_REAL)nums[1],
+                          (TOBJ_REAL)nums[2]};
+      uint8_t wh = (n == 4);
+      TOBJ_REAL wv = wh ? (TOBJ_REAL)nums[3] : (TOBJ_REAL)1;
+      if (!tobj_vec_append(&w->lv, xyz, 3, a) ||
+          !tobj_vec_append(&w->lvw, &wv, 1, a) ||
+          !tobj_vec_append(&w->lvw_has, &wh, 1, a)) {
+        w->oom = true;
+        return;
+      }
+      if (w->store_colors) {
+        uint8_t ch = (n >= 6);
+        TOBJ_REAL rgb[3] = {ch ? (TOBJ_REAL)nums[3] : (TOBJ_REAL)1,
+                            ch ? (TOBJ_REAL)nums[4] : (TOBJ_REAL)1,
+                            ch ? (TOBJ_REAL)nums[5] : (TOBJ_REAL)1};
+        if (!tobj_vec_append(&w->lcol, rgb, 3, a) ||
+            !tobj_vec_append(&w->lcol_has, &ch, 1, a)) {
+          w->oom = true;
+          return;
+        }
+      }
+    } else if (tobj_slice_eq(tok, tl, "vn")) {
+      TOBJ_REAL xyz[3] = {0, 0, 0};
+      double d;
+      for (int k = 0; k < 3; k++)
+        if (tobj_scan_double(&c.p, c.end, &d)) xyz[k] = (TOBJ_REAL)d;
+      if (!tobj_vec_append(&w->lvn, xyz, 3, a)) {
+        w->oom = true;
+        return;
+      }
+    } else if (tobj_slice_eq(tok, tl, "vt")) {
+      double d;
+      TOBJ_REAL uv[2] = {0, 0};
+      int n = 0;
+      for (; n < 2; n++) {
+        if (!tobj_scan_double(&c.p, c.end, &d)) break;
+        uv[n] = (TOBJ_REAL)d;
+      }
+      uint8_t wh = (uint8_t)tobj_scan_double(&c.p, c.end, &d);
+      TOBJ_REAL wv = wh ? (TOBJ_REAL)d : (TOBJ_REAL)0;
+      if (!tobj_vec_append(&w->lvt, uv, 2, a) ||
+          !tobj_vec_append(&w->lvtw, &wv, 1, a) ||
+          !tobj_vec_append(&w->lvtw_has, &wh, 1, a)) {
+        w->oom = true;
+        return;
+      }
+    } else if (w->parse_vp && tobj_slice_eq(tok, tl, "vp")) {
+      double d;
+      int n = 0;
+      TOBJ_REAL uvw[3] = {0, 0, 0};
+      for (; n < 3; n++) {
+        if (!tobj_scan_double(&c.p, c.end, &d)) break;
+        uvw[n] = (TOBJ_REAL)d;
+      }
+      if (n < 1) continue;
+      if (n > w->vp_comps) w->vp_comps = n;
+      if (!tobj_vec_append(&w->lvp, uvw, (size_t)n, a)) {
+        w->oom = true;
+        return;
+      }
+    }
+  }
+}
+
+/* Reconstruct a lazy optional array (weights/colors/texcoord-w) from the
+ * per-thread (value,has) streams, reproducing the single-threaded semantics
+ * exactly: empty until the first present entry, then dense with backfill. */
+static bool TOBJ_T(mt_lazy)(tobj_vec *dst, size_t comps, const TOBJ_REAL *dflt,
+                            TOBJ_T(tobj_tls) * tls, int T, int kind,
+                            const tobj_allocator *a) {
+  bool started = false;
+  size_t gi = 0;
+  for (int t = 0; t < T; t++) {
+    tobj_vec *vval = (kind == 0) ? &tls[t].lvw
+                                 : (kind == 1) ? &tls[t].lcol : &tls[t].lvtw;
+    tobj_vec *vhas = (kind == 0) ? &tls[t].lvw_has
+                                 : (kind == 1) ? &tls[t].lcol_has
+                                               : &tls[t].lvtw_has;
+    size_t cnt = vhas->count;
+    const TOBJ_REAL *val = (const TOBJ_REAL *)vval->data;
+    const uint8_t *has = (const uint8_t *)vhas->data;
+    for (size_t j = 0; j < cnt; j++, gi++) {
+      if (has[j] || started) {
+        if (!started) {
+          for (size_t k = 0; k < gi; k++)
+            if (!tobj_vec_append(dst, dflt, comps, a)) return false;
+          started = true;
+        }
+        if (!tobj_vec_append(dst, &val[j * comps], comps, a)) return false;
+      }
+    }
+  }
+  return true;
+}
+
+/* MT pass 1: parse v/vn/vt/vp in parallel and merge into the builder's attrib
+ * arrays, reproducing single-threaded output exactly. Sets b->prefilled. */
+static bool TOBJ_T(mt_prepass)(TOBJ_T(tobj_builder) * b, const tobj_vec *lines,
+                               const char *base, int T) {
+  const tobj_allocator *a = b->alloc;
+  TOBJ_T(tobj_tls) *tls =
+      (TOBJ_T(tobj_tls) *)tobj_alloc(a, (size_t)T * sizeof(*tls), 16);
+  tobj_thunk *thunks = (tobj_thunk *)tobj_alloc(a, (size_t)T * sizeof(*thunks),
+                                                16);
+  if (!tls || !thunks) {
+    if (tls) tobj_free(a, tls, (size_t)T * sizeof(*tls));
+    if (thunks) tobj_free(a, thunks, (size_t)T * sizeof(*thunks));
+    return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  }
+  size_t nlines = lines->count;
+  const tobj_line *ld = (const tobj_line *)lines->data;
+  for (int t = 0; t < T; t++) {
+    tobj_memset(&tls[t], 0, sizeof tls[t]);
+    tls[t].base = base;
+    tls[t].lines = ld;
+    tls[t].lo = (size_t)t * nlines / (size_t)T;
+    tls[t].hi = (size_t)(t + 1) * nlines / (size_t)T;
+    tls[t].alloc = a;
+    tls[t].store_colors = b->cfg->store_vertex_colors;
+    tls[t].parse_vp = b->cfg->parse_freeform;
+    tobj_vec_init(&tls[t].lv, sizeof(TOBJ_REAL));
+    tobj_vec_init(&tls[t].lvw, sizeof(TOBJ_REAL));
+    tobj_vec_init(&tls[t].lvw_has, 1);
+    tobj_vec_init(&tls[t].lcol, sizeof(TOBJ_REAL));
+    tobj_vec_init(&tls[t].lcol_has, 1);
+    tobj_vec_init(&tls[t].lvn, sizeof(TOBJ_REAL));
+    tobj_vec_init(&tls[t].lvt, sizeof(TOBJ_REAL));
+    tobj_vec_init(&tls[t].lvtw, sizeof(TOBJ_REAL));
+    tobj_vec_init(&tls[t].lvtw_has, 1);
+    tobj_vec_init(&tls[t].lvp, sizeof(TOBJ_REAL));
+    thunks[t].fn = TOBJ_T(mt_worker);
+    thunks[t].arg = &tls[t];
+  }
+
+  tobj_run_parallel(thunks, T);
+
+  bool ok = true;
+  for (int t = 0; t < T; t++)
+    if (tls[t].oom) ok = false;
+
+  /* merge plain arrays in thread (= file) order */
+  for (int t = 0; ok && t < T; t++) {
+    if (!tobj_vec_append(&b->av, tls[t].lv.data, tls[t].lv.count, a) ||
+        !tobj_vec_append(&b->avn, tls[t].lvn.data, tls[t].lvn.count, a) ||
+        !tobj_vec_append(&b->avt, tls[t].lvt.data, tls[t].lvt.count, a))
+      ok = false;
+    if (ok && b->cfg->parse_freeform && tls[t].lvp.count) {
+      if (!tobj_vec_append(&b->ff_vp, tls[t].lvp.data, tls[t].lvp.count, a))
+        ok = false;
+      if (tls[t].vp_comps > b->ff_vp_comps) b->ff_vp_comps = tls[t].vp_comps;
+    }
+  }
+  /* reconstruct lazy optional arrays */
+  if (ok) {
+    TOBJ_REAL d1 = (TOBJ_REAL)1, d0 = (TOBJ_REAL)0;
+    TOBJ_REAL white[3] = {(TOBJ_REAL)1, (TOBJ_REAL)1, (TOBJ_REAL)1};
+    if (!TOBJ_T(mt_lazy)(&b->avw, 1, &d1, tls, T, 0, a)) ok = false;
+    if (ok && b->cfg->store_vertex_colors &&
+        !TOBJ_T(mt_lazy)(&b->acol, 3, white, tls, T, 1, a))
+      ok = false;
+    if (ok && !TOBJ_T(mt_lazy)(&b->avtw, 1, &d0, tls, T, 2, a)) ok = false;
+  }
+
+  for (int t = 0; t < T; t++) {
+    tobj_vec_free(&tls[t].lv, a);
+    tobj_vec_free(&tls[t].lvw, a);
+    tobj_vec_free(&tls[t].lvw_has, a);
+    tobj_vec_free(&tls[t].lcol, a);
+    tobj_vec_free(&tls[t].lcol_has, a);
+    tobj_vec_free(&tls[t].lvn, a);
+    tobj_vec_free(&tls[t].lvt, a);
+    tobj_vec_free(&tls[t].lvtw, a);
+    tobj_vec_free(&tls[t].lvtw_has, a);
+    tobj_vec_free(&tls[t].lvp, a);
+  }
+  tobj_free(a, tls, (size_t)T * sizeof(*tls));
+  tobj_free(a, thunks, (size_t)T * sizeof(*thunks));
+  if (!ok) return TOBJ_T(b_fail)(b, TOBJ_ERR_ALLOC);
+  b->prefilled = true;
+  return true;
+}
+#endif /* TOBJ_ENABLE_MULTITHREADING */
+
+tobj_result TOBJ_T(tobj_load_obj_from_memory)(TOBJ_T(tobj_scene) * out,
+                                              const uint8_t *buf, size_t len,
+                                              const tobj_load_config *cfg,
+                                              tobj_diag *diag) {
+  if (!out) return TOBJ_ERR_INVALID_ARG;
+  tobj_memset(out, 0, sizeof *out);
+  if (!buf && len) return TOBJ_ERR_INVALID_ARG;
+
+  tobj_load_config defcfg;
+  if (!cfg) {
+    defcfg = tobj_default_config();
+    cfg = &defcfg;
+  }
+
+  tobj_allocator alloc;
+  if (cfg->allocator.alloc) {
+    alloc = cfg->allocator;
+  } else {
+#ifndef TOBJ_NO_LIBC
+    alloc = tobj_default_allocator();
+#else
+    return TOBJ_ERR_INVALID_ARG;
+#endif
+  }
+
+  tobj_arena *arena = (tobj_arena *)tobj_alloc(&alloc, sizeof(tobj_arena), 16);
+  if (!arena) return TOBJ_ERR_ALLOC;
+  tobj_arena_init(arena, &alloc, cfg->use_arena ? (size_t)(1u << 20) : 0);
+
+  TOBJ_T(tobj_builder) b;
+  tobj_memset(&b, 0, sizeof b);
+  b.alloc = &alloc;
+  b.arena = arena;
+  b.diag = diag;
+  b.cfg = cfg;
+  b.caps = tobj_resolve_caps(cfg);
+  b.err = TOBJ_OK;
+  b.triangulate = cfg->triangulate;
+  b.cur_material = -1;
+  b.cur_smooth = 0;
+  b.cur_name = NULL;
+  TOBJ_T(builder_init)(&b);
+
+  tobj_vec lines;
+  tobj_vec_init(&lines, sizeof(tobj_line));
+  if (!tobj_build_line_index(buf, len, &lines, &alloc)) {
+    b.err = TOBJ_ERR_ALLOC;
+  }
+
+  const char *base = (const char *)buf;
+
+#ifdef TOBJ_ENABLE_MULTITHREADING
+  if (b.err == TOBJ_OK) {
+    int T = cfg->num_threads < 0 ? (int)tobj_hw_threads() : cfg->num_threads;
+    if (T > 64) T = 64;
+    /* Only worth threading on sizeable inputs. */
+    if (T > 1 && lines.count >= (size_t)(256 * T)) {
+      TOBJ_T(mt_prepass)(&b, &lines, base, T);
+    }
+  }
+#endif
+
+  for (size_t i = 0; i < lines.count && b.err == TOBJ_OK; i++) {
+    tobj_line *ln = (tobj_line *)tobj_vec_at(&lines, i);
+    b.line = i + 1;
+    TOBJ_T(dispatch_line)(&b, base + ln->pos, ln->len);
+  }
+
+  if (b.err == TOBJ_OK) TOBJ_T(finalize_shape)(&b);
+
+  /* vertex color fallback: fill white if requested and none present */
+  if (b.err == TOBJ_OK && cfg->store_vertex_colors &&
+      cfg->vertex_color_fallback && b.acol.count == 0) {
+    size_t numv = b.av.count / 3u;
+    TOBJ_REAL white[3] = {(TOBJ_REAL)1, (TOBJ_REAL)1, (TOBJ_REAL)1};
+    for (size_t i = 0; i < numv && b.err == TOBJ_OK; i++) {
+      if (!tobj_vec_append(&b.acol, white, 3, &alloc)) b.err = TOBJ_ERR_ALLOC;
+    }
+  }
+
+  if (b.err == TOBJ_OK) {
+#define TOBJ_FIN_BUF(field, vec)                                        \
+  do {                                                                  \
+    out->attrib.field.count = (vec).count;                              \
+    out->attrib.field.ptr =                                             \
+        (TOBJ_REAL *)tobj_vec_finalize(&(vec), arena, 16);              \
+    if ((vec).count && !out->attrib.field.ptr) b.err = TOBJ_ERR_ALLOC;  \
+  } while (0)
+    TOBJ_FIN_BUF(vertices, b.av);
+    TOBJ_FIN_BUF(vertex_weights, b.avw);
+    TOBJ_FIN_BUF(normals, b.avn);
+    TOBJ_FIN_BUF(texcoords, b.avt);
+    TOBJ_FIN_BUF(texcoord_ws, b.avtw);
+    TOBJ_FIN_BUF(colors, b.acol);
+#undef TOBJ_FIN_BUF
+  }
+
+  if (b.err == TOBJ_OK) TOBJ_T(finalize_unknowns)(&b);
+
+  if (b.err == TOBJ_OK) {
+    out->num_shapes = b.shapes.count;
+    out->shapes = (TOBJ_T(tobj_shape) *)tobj_vec_finalize(
+        &b.shapes, arena, 16);
+    if (b.shapes.count && !out->shapes) b.err = TOBJ_ERR_ALLOC;
+    out->num_materials = b.materials.count;
+    out->materials = (TOBJ_T(tobj_material) *)tobj_vec_finalize(
+        &b.materials, arena, 16);
+    if (b.materials.count && !out->materials) b.err = TOBJ_ERR_ALLOC;
+  }
+
+  TOBJ_T(builder_dispose)(&b);
+  tobj_vec_free(&lines, &alloc);
+
+  if (b.err != TOBJ_OK) {
+    tobj_arena_destroy(arena);
+    tobj_free(&alloc, arena, sizeof(tobj_arena));
+    tobj_memset(out, 0, sizeof *out);
+    return b.err;
+  }
+
+  out->allocator = alloc;
+  out->arena = arena;
+  out->strpool = NULL;
+  return TOBJ_OK;
+}
+
+#ifdef TOBJ_ENABLE_FILE_IO
+tobj_result TOBJ_T(tobj_load_obj_from_file)(TOBJ_T(tobj_scene) * out,
+                                            const char *path,
+                                            const tobj_load_config *cfg,
+                                            tobj_diag *diag) {
+  if (!out) return TOBJ_ERR_INVALID_ARG;
+  tobj_memset(out, 0, sizeof *out);
+  if (!path) return TOBJ_ERR_INVALID_ARG;
+
+  tobj_load_config cc = cfg ? *cfg : tobj_default_config();
+  tobj_allocator alloc;
+  if (cc.allocator.alloc) {
+    alloc = cc.allocator;
+  } else {
+    alloc = tobj_default_allocator();
+    cc.allocator = alloc;
+  }
+
+  tobj_file_buf fb;
+  tobj_result r = tobj_file_open(&fb, path, &alloc);
+  if (r != TOBJ_OK) return r;
+
+  size_t dlen;
+  char *basedir = tobj_dirname_dup(path, &alloc, &dlen);
+  if (!basedir) {
+    tobj_file_close(&fb);
+    return TOBJ_ERR_ALLOC;
+  }
+  tobj_file_res_ctx ctx;
+  ctx.basedir = basedir;
+  ctx.alloc = alloc;
+  if (!cc.mtl_resolver) {
+    cc.mtl_resolver = tobj_file_material_resolver;
+    cc.mtl_resolver_user_data = &ctx;
+  }
+
+  r = TOBJ_T(tobj_load_obj_from_memory)(out, fb.data, fb.len, &cc, diag);
+
+  tobj_free(&alloc, basedir, dlen + 1);
+  tobj_file_close(&fb);
+  return r;
+}
+#endif /* TOBJ_ENABLE_FILE_IO */
+
+/* ----------------------------------------------------------------------- */
+/* standalone .mtl parsing                                                 */
+/* ----------------------------------------------------------------------- */
+
+tobj_result TOBJ_T(tobj_parse_mtl_from_memory)(TOBJ_T(tobj_material_list) * out,
+                                               const uint8_t *buf, size_t len,
+                                               const tobj_load_config *cfg,
+                                               tobj_diag *diag) {
+  if (!out) return TOBJ_ERR_INVALID_ARG;
+  tobj_memset(out, 0, sizeof *out);
+  if (!buf && len) return TOBJ_ERR_INVALID_ARG;
+
+  tobj_load_config defcfg;
+  if (!cfg) {
+    defcfg = tobj_default_config();
+    cfg = &defcfg;
+  }
+  tobj_allocator alloc;
+  if (cfg->allocator.alloc) {
+    alloc = cfg->allocator;
+  } else {
+#ifndef TOBJ_NO_LIBC
+    alloc = tobj_default_allocator();
+#else
+    return TOBJ_ERR_INVALID_ARG;
+#endif
+  }
+  tobj_arena *arena = (tobj_arena *)tobj_alloc(&alloc, sizeof(tobj_arena), 16);
+  if (!arena) return TOBJ_ERR_ALLOC;
+  tobj_arena_init(arena, &alloc, 0);
+
+  TOBJ_T(tobj_builder) b;
+  tobj_memset(&b, 0, sizeof b);
+  b.alloc = &alloc;
+  b.arena = arena;
+  b.diag = diag;
+  b.cfg = cfg;
+  b.caps = tobj_resolve_caps(cfg);
+  b.err = TOBJ_OK;
+  TOBJ_T(builder_init)(&b);
+
+  TOBJ_T(parse_mtl_buffer)(&b, buf, len);
+  if (b.err == TOBJ_OK) TOBJ_T(finalize_unknowns)(&b);
+
+  if (b.err == TOBJ_OK) {
+    out->count = b.materials.count;
+    out->items = (TOBJ_T(tobj_material) *)tobj_vec_finalize(&b.materials,
+                                                            arena, 16);
+    if (b.materials.count && !out->items) b.err = TOBJ_ERR_ALLOC;
+  }
+
+  TOBJ_T(builder_dispose)(&b);
+
+  if (b.err != TOBJ_OK) {
+    tobj_arena_destroy(arena);
+    tobj_free(&alloc, arena, sizeof(tobj_arena));
+    tobj_memset(out, 0, sizeof *out);
+    return b.err;
+  }
+  out->allocator = alloc;
+  out->strpool = arena;
+  return TOBJ_OK;
+}
+
+void TOBJ_T(tobj_material_list_free)(TOBJ_T(tobj_material_list) * list) {
+  if (!list) return;
+  if (list->strpool) {
+    tobj_arena *ar = (tobj_arena *)list->strpool;
+    tobj_allocator a = list->allocator;
+    tobj_arena_destroy(ar);
+    tobj_free(&a, ar, sizeof(tobj_arena));
+  }
+  tobj_memset(list, 0, sizeof *list);
+}
+
+/* ----------------------------------------------------------------------- */
+/* streaming callback API                                                  */
+/* ----------------------------------------------------------------------- */
+
+tobj_result TOBJ_T(tobj_load_obj_with_callbacks)(
+    const uint8_t *buf, size_t len, const TOBJ_T(tobj_callbacks) * cb,
+    const tobj_load_config *cfg, tobj_diag *diag) {
+  if (!cb) return TOBJ_ERR_INVALID_ARG;
+  if (!buf && len) return TOBJ_ERR_INVALID_ARG;
+
+  tobj_load_config defcfg;
+  if (!cfg) {
+    defcfg = tobj_default_config();
+    cfg = &defcfg;
+  }
+  tobj_allocator alloc;
+  if (cfg->allocator.alloc) {
+    alloc = cfg->allocator;
+  } else {
+#ifndef TOBJ_NO_LIBC
+    alloc = tobj_default_allocator();
+#else
+    return TOBJ_ERR_INVALID_ARG;
+#endif
+  }
+  tobj_arena *arena = (tobj_arena *)tobj_alloc(&alloc, sizeof(tobj_arena), 16);
+  if (!arena) return TOBJ_ERR_ALLOC;
+  tobj_arena_init(arena, &alloc, 0);
+
+  TOBJ_T(tobj_builder) b;
+  tobj_memset(&b, 0, sizeof b);
+  b.alloc = &alloc;
+  b.arena = arena;
+  b.diag = diag;
+  b.cfg = cfg;
+  b.caps = tobj_resolve_caps(cfg);
+  b.err = TOBJ_OK;
+  TOBJ_T(builder_init)(&b);
+  void *ud = cb->user_data;
+
+  tobj_vec lines;
+  tobj_vec_init(&lines, sizeof(tobj_line));
+  if (!tobj_build_line_index(buf, len, &lines, &alloc)) b.err = TOBJ_ERR_ALLOC;
+
+  size_t numv = 0, numvt = 0, numvn = 0;
+  const char *base = (const char *)buf;
+
+  for (size_t i = 0; i < lines.count && b.err == TOBJ_OK; i++) {
+    tobj_line *ln = (tobj_line *)tobj_vec_at(&lines, i);
+    b.line = i + 1;
+    if (ln->len > b.caps.line_bytes) {
+      b.err = TOBJ_ERR_LIMIT_EXCEEDED;
+      break;
+    }
+    tobj_cursor c;
+    tobj_cur_init(&c, base + ln->pos, ln->len);
+    const char *tok;
+    size_t tl;
+    if (!tobj_next_token(&c, &tok, &tl)) continue;
+    if (tok[0] == '#') continue;
+
+    if (tobj_slice_eq(tok, tl, "v")) {
+      double nums[8];
+      int n = 0;
+      while (n < 8) {
+        double d;
+        const char *save = c.p;
+        if (!tobj_scan_double(&c.p, c.end, &d)) {
+          c.p = save;
+          break;
+        }
+        nums[n++] = d;
+      }
+      while (n < 3) nums[n++] = 0.0;
+      TOBJ_REAL w = (n == 4) ? (TOBJ_REAL)nums[3] : (TOBJ_REAL)1;
+      if (cb->vertex_cb)
+        cb->vertex_cb(ud, (TOBJ_REAL)nums[0], (TOBJ_REAL)nums[1],
+                      (TOBJ_REAL)nums[2], w);
+      if (cb->vertex_color_cb) {
+        bool hc = n >= 6;
+        cb->vertex_color_cb(ud, (TOBJ_REAL)nums[0], (TOBJ_REAL)nums[1],
+                            (TOBJ_REAL)nums[2],
+                            hc ? (TOBJ_REAL)nums[3] : (TOBJ_REAL)1,
+                            hc ? (TOBJ_REAL)nums[4] : (TOBJ_REAL)1,
+                            hc ? (TOBJ_REAL)nums[5] : (TOBJ_REAL)1, hc);
+      }
+      numv++;
+    } else if (tobj_slice_eq(tok, tl, "vn")) {
+      double d;
+      TOBJ_REAL xyz[3] = {0, 0, 0};
+      for (int k = 0; k < 3; k++)
+        if (tobj_scan_double(&c.p, c.end, &d)) xyz[k] = (TOBJ_REAL)d;
+      if (cb->normal_cb) cb->normal_cb(ud, xyz[0], xyz[1], xyz[2]);
+      numvn++;
+    } else if (tobj_slice_eq(tok, tl, "vt")) {
+      double d;
+      TOBJ_REAL uvw[3] = {0, 0, 0};
+      for (int k = 0; k < 3; k++)
+        if (tobj_scan_double(&c.p, c.end, &d)) uvw[k] = (TOBJ_REAL)d;
+      if (cb->texcoord_cb) cb->texcoord_cb(ud, uvw[0], uvw[1], uvw[2]);
+      numvt++;
+    } else if (tobj_slice_eq(tok, tl, "f") || tobj_slice_eq(tok, tl, "l") ||
+               tobj_slice_eq(tok, tl, "p")) {
+      char kind = tok[0];
+      b.corners.count = 0;
+      const char *t2;
+      size_t l2;
+      while (tobj_next_token(&c, &t2, &l2)) {
+        tobj_index *slot = (tobj_index *)tobj_vec_push(&b.corners, &alloc);
+        if (!slot) {
+          b.err = TOBJ_ERR_ALLOC;
+          break;
+        }
+        TOBJ_T(parse_corner_n)(t2, l2, numv, numvt, numvn, slot);
+      }
+      if (b.err != TOBJ_OK) break;
+      int nidx = tobj_size_to_int(b.corners.count);
+      const tobj_index *ci = (const tobj_index *)b.corners.data;
+      if (kind == 'f' && cb->index_cb && nidx >= 3)
+        cb->index_cb(ud, ci, nidx);
+      else if (kind == 'l' && cb->line_cb && nidx >= 2)
+        cb->line_cb(ud, ci, nidx);
+      else if (kind == 'p' && cb->point_cb && nidx >= 1)
+        cb->point_cb(ud, ci, nidx);
+    } else if (tobj_slice_eq(tok, tl, "g") || tobj_slice_eq(tok, tl, "o")) {
+      const char *name = TOBJ_T(intern_rest)(&b, &c);
+      if (!name) {
+        b.err = TOBJ_ERR_ALLOC;
+        break;
+      }
+      if (tok[0] == 'o') {
+        if (cb->object_cb) cb->object_cb(ud, name);
+      } else {
+        if (cb->group_cb) {
+          const char *names[1] = {name};
+          cb->group_cb(ud, names, 1);
+        }
+      }
+    } else if (tobj_slice_eq(tok, tl, "usemtl")) {
+      const char *p = c.p, *e = c.end;
+      while (p < e && tobj_is_space(*p)) p++;
+      while (e > p && tobj_is_space(e[-1])) e--;
+      int id = TOBJ_T(mat_find)(&b, p, (size_t)(e - p));
+      if (cb->usemtl_cb) {
+        const char *name = tobj_intern(arena, p, (size_t)(e - p));
+        cb->usemtl_cb(ud, name, id);
+      }
+    } else if (tobj_slice_eq(tok, tl, "mtllib")) {
+      if (cfg->mtl_resolver) {
+        const char *t2;
+        size_t l2;
+        size_t before = b.materials.count;
+        while (tobj_next_token(&c, &t2, &l2)) {
+          char *name = (char *)tobj_arena_alloc(arena, l2 + 1, 1);
+          if (!name) {
+            b.err = TOBJ_ERR_ALLOC;
+            break;
+          }
+          tobj_memcpy(name, t2, l2);
+          name[l2] = '\0';
+          tobj_mtl_source src;
+          tobj_memset(&src, 0, sizeof src);
+          if (cfg->mtl_resolver(cfg->mtl_resolver_user_data, name, &src) ==
+              TOBJ_OK) {
+            TOBJ_T(parse_mtl_buffer)(&b, src.data, src.len);
+            if (src.release) src.release(src.release_ud, src.data, src.len);
+          }
+        }
+        if (b.err == TOBJ_OK && cb->mtllib_cb && b.materials.count > before) {
+          cb->mtllib_cb(ud, (const TOBJ_T(tobj_material) *)b.materials.data,
+                        tobj_size_to_int(b.materials.count));
+        }
+      }
+    }
+  }
+
+  TOBJ_T(builder_dispose)(&b);
+  tobj_vec_free(&lines, &alloc);
+  tobj_arena_destroy(arena);
+  tobj_free(&alloc, arena, sizeof(tobj_arena));
+  return b.err;
+}

--- a/tiny_obj_c_pub.inc
+++ b/tiny_obj_c_pub.inc
@@ -1,0 +1,275 @@
+/*
+ * tiny_obj_c_pub.inc -- per-precision public types and prototypes.
+ *
+ * Included twice from tiny_obj_c.h with (TOBJ_REAL, TOBJ_SUF) set to
+ * (float, _f) and (double, _d). Do not include directly.
+ *
+ * TOBJ_T(x) pastes the active suffix; e.g. TOBJ_T(tobj_scene) -> tobj_scene_f.
+ */
+
+typedef struct TOBJ_T(tobj_real_buf) {
+  TOBJ_REAL *ptr;
+  size_t count;
+} TOBJ_T(tobj_real_buf);
+
+typedef struct TOBJ_T(tobj_texture_option) {
+  tobj_texture_type type;
+  TOBJ_REAL sharpness;          /* -boost */
+  TOBJ_REAL brightness;         /* -mm base */
+  TOBJ_REAL contrast;           /* -mm gain */
+  TOBJ_REAL origin_offset[3];   /* -o */
+  TOBJ_REAL scale[3];           /* -s */
+  TOBJ_REAL turbulence[3];      /* -t */
+  int texture_resolution;       /* -texres (-1 = unset) */
+  bool clamp;                   /* -clamp */
+  bool blendu;                  /* -blendu (default on) */
+  bool blendv;                  /* -blendv (default on) */
+  char imfchan;                 /* -imfchan */
+  TOBJ_REAL bump_multiplier;    /* -bm */
+  const char *colorspace;       /* extension; interned, never NULL ("" if unset) */
+} TOBJ_T(tobj_texture_option);
+
+typedef struct TOBJ_T(tobj_material) {
+  const char *name;
+
+  TOBJ_REAL ambient[3];
+  TOBJ_REAL diffuse[3];
+  TOBJ_REAL specular[3];
+  TOBJ_REAL transmittance[3];
+  TOBJ_REAL emission[3];
+  TOBJ_REAL shininess;
+  TOBJ_REAL ior;
+  TOBJ_REAL dissolve;           /* 1 = opaque */
+  int illum;
+
+  /* PBR extension. */
+  TOBJ_REAL roughness;
+  TOBJ_REAL metallic;
+  TOBJ_REAL sheen;
+  TOBJ_REAL clearcoat_thickness;
+  TOBJ_REAL clearcoat_roughness;
+  TOBJ_REAL anisotropy;
+  TOBJ_REAL anisotropy_rotation;
+
+  /* Classic texture maps. */
+  const char *ambient_texname;
+  const char *diffuse_texname;
+  const char *specular_texname;
+  const char *specular_highlight_texname;
+  const char *bump_texname;
+  const char *displacement_texname;
+  const char *alpha_texname;
+  const char *reflection_texname;
+  /* PBR texture maps. */
+  const char *roughness_texname;
+  const char *metallic_texname;
+  const char *sheen_texname;
+  const char *emissive_texname;
+  const char *normal_texname;
+
+  TOBJ_T(tobj_texture_option) ambient_texopt;
+  TOBJ_T(tobj_texture_option) diffuse_texopt;
+  TOBJ_T(tobj_texture_option) specular_texopt;
+  TOBJ_T(tobj_texture_option) specular_highlight_texopt;
+  TOBJ_T(tobj_texture_option) bump_texopt;
+  TOBJ_T(tobj_texture_option) displacement_texopt;
+  TOBJ_T(tobj_texture_option) alpha_texopt;
+  TOBJ_T(tobj_texture_option) reflection_texopt;
+  TOBJ_T(tobj_texture_option) roughness_texopt;
+  TOBJ_T(tobj_texture_option) metallic_texopt;
+  TOBJ_T(tobj_texture_option) sheen_texopt;
+  TOBJ_T(tobj_texture_option) emissive_texopt;
+  TOBJ_T(tobj_texture_option) normal_texopt;
+
+  /* Unknown parameters: sorted-by-key array, binary searchable. */
+  tobj_kv *unknown_params;
+  size_t num_unknown_params;
+} TOBJ_T(tobj_material);
+
+typedef struct TOBJ_T(tobj_joint_weight) {
+  int joint_id;
+  TOBJ_REAL weight;
+} TOBJ_T(tobj_joint_weight);
+
+typedef struct TOBJ_T(tobj_skin_weight) {
+  int vertex_id;
+  TOBJ_T(tobj_joint_weight) * weights;
+  size_t num_weights;
+} TOBJ_T(tobj_skin_weight);
+
+typedef struct TOBJ_T(tobj_tag) {
+  const char *name;
+  int *int_values;
+  size_t num_int_values;
+  TOBJ_REAL *float_values;
+  size_t num_float_values;
+  const char **string_values;
+  size_t num_string_values;
+} TOBJ_T(tobj_tag);
+
+typedef struct TOBJ_T(tobj_attrib) {
+  TOBJ_T(tobj_real_buf) vertices;        /* xyz */
+  TOBJ_T(tobj_real_buf) vertex_weights;  /* w (empty if none) */
+  TOBJ_T(tobj_real_buf) normals;         /* xyz */
+  TOBJ_T(tobj_real_buf) texcoords;       /* uv */
+  TOBJ_T(tobj_real_buf) texcoord_ws;     /* w (empty if none) */
+  TOBJ_T(tobj_real_buf) colors;          /* rgb (empty unless present/forced) */
+  TOBJ_T(tobj_skin_weight) * skin_weights;
+  size_t num_skin_weights;
+} TOBJ_T(tobj_attrib);
+
+typedef struct TOBJ_T(tobj_mesh) {
+  tobj_index *indices;
+  size_t num_indices;
+  unsigned int *num_face_vertices;   /* per face; len == num_faces */
+  int *material_ids;                 /* per face */
+  unsigned int *smoothing_group_ids; /* per face; 0 = off */
+  size_t num_faces;
+  TOBJ_T(tobj_tag) * tags;
+  size_t num_tags;
+} TOBJ_T(tobj_mesh);
+
+typedef struct TOBJ_T(tobj_lines) {
+  tobj_index *indices;
+  size_t num_indices;
+  int *num_line_vertices; /* per polyline */
+  size_t num_lines;
+} TOBJ_T(tobj_lines);
+
+typedef struct TOBJ_T(tobj_points) {
+  tobj_index *indices;
+  size_t num_indices;
+} TOBJ_T(tobj_points);
+
+/* ---- free-form geometry (parse & retain; no NURBS evaluation) ---------- */
+
+typedef struct TOBJ_T(tobj_param_verts) { /* vp */
+  TOBJ_T(tobj_real_buf) uvw; /* packed u[v[w]] */
+  int components;            /* 1..3 */
+} TOBJ_T(tobj_param_verts);
+
+typedef struct TOBJ_T(tobj_curve) { /* curv */
+  tobj_cstype type;
+  bool rational;
+  int degree;
+  TOBJ_REAL u0, u1;
+  int *control_points; /* resolved v indices */
+  size_t num_control_points;
+  TOBJ_REAL *knots; /* from parm u */
+  size_t num_knots;
+} TOBJ_T(tobj_curve);
+
+typedef struct TOBJ_T(tobj_curve2) { /* curv2 (parameter space) */
+  tobj_cstype type;
+  bool rational;
+  int degree;
+  int *control_points; /* resolved vp indices */
+  size_t num_control_points;
+  TOBJ_REAL *knots;
+  size_t num_knots;
+} TOBJ_T(tobj_curve2);
+
+typedef struct TOBJ_T(tobj_trim_loop) { /* trim/hole/scrv entry */
+  TOBJ_REAL u0, u1;
+  int curve2_index;
+} TOBJ_T(tobj_trim_loop);
+
+typedef struct TOBJ_T(tobj_surface) { /* surf */
+  tobj_cstype type;
+  bool rational;
+  int degu, degv;
+  TOBJ_REAL s0, s1, t0, t1;
+  tobj_index *control_points; /* v/vt/vn refs */
+  size_t num_control_points;
+  TOBJ_REAL *knots_u;
+  size_t num_knots_u;
+  TOBJ_REAL *knots_v;
+  size_t num_knots_v;
+  TOBJ_T(tobj_trim_loop) * trims;
+  size_t num_trims;
+  TOBJ_T(tobj_trim_loop) * holes;
+  size_t num_holes;
+  TOBJ_T(tobj_trim_loop) * scrvs;
+  size_t num_scrvs;
+} TOBJ_T(tobj_surface);
+
+typedef struct TOBJ_T(tobj_freeform) {
+  TOBJ_T(tobj_param_verts) vp;
+  TOBJ_T(tobj_curve) * curves;
+  size_t num_curves;
+  TOBJ_T(tobj_curve2) * curves2;
+  size_t num_curves2;
+  TOBJ_T(tobj_surface) * surfaces;
+  size_t num_surfaces;
+} TOBJ_T(tobj_freeform);
+
+typedef struct TOBJ_T(tobj_shape) {
+  const char *name;
+  TOBJ_T(tobj_mesh) mesh;
+  TOBJ_T(tobj_lines) lines;
+  TOBJ_T(tobj_points) points;
+  TOBJ_T(tobj_freeform) * freeform; /* NULL unless parse_freeform and present */
+} TOBJ_T(tobj_shape);
+
+typedef struct TOBJ_T(tobj_scene) {
+  TOBJ_T(tobj_attrib) attrib;
+  TOBJ_T(tobj_shape) * shapes;
+  size_t num_shapes;
+  TOBJ_T(tobj_material) * materials;
+  size_t num_materials;
+  /* bookkeeping for one-shot teardown (opaque to callers) */
+  tobj_allocator allocator;
+  void *arena;
+  void *strpool;
+} TOBJ_T(tobj_scene);
+
+typedef struct TOBJ_T(tobj_material_list) {
+  TOBJ_T(tobj_material) * items;
+  size_t count;
+  tobj_allocator allocator;
+  void *strpool;
+} TOBJ_T(tobj_material_list);
+
+typedef struct TOBJ_T(tobj_callbacks) {
+  void (*vertex_cb)(void *ud, TOBJ_REAL x, TOBJ_REAL y, TOBJ_REAL z,
+                    TOBJ_REAL w);
+  void (*vertex_color_cb)(void *ud, TOBJ_REAL x, TOBJ_REAL y, TOBJ_REAL z,
+                          TOBJ_REAL r, TOBJ_REAL g, TOBJ_REAL b, bool has_color);
+  void (*normal_cb)(void *ud, TOBJ_REAL x, TOBJ_REAL y, TOBJ_REAL z);
+  void (*texcoord_cb)(void *ud, TOBJ_REAL x, TOBJ_REAL y, TOBJ_REAL z);
+  void (*index_cb)(void *ud, const tobj_index *indices, int num_indices);
+  void (*usemtl_cb)(void *ud, const char *name, int material_id);
+  void (*mtllib_cb)(void *ud, const TOBJ_T(tobj_material) * materials, int num);
+  void (*group_cb)(void *ud, const char *const *names, int num_names);
+  void (*object_cb)(void *ud, const char *name);
+  void (*line_cb)(void *ud, const tobj_index *indices, int num_indices);
+  void (*point_cb)(void *ud, const tobj_index *indices, int num_indices);
+  void *user_data;
+} TOBJ_T(tobj_callbacks);
+
+/* ---- entry points ------------------------------------------------------ */
+
+TOBJ_API tobj_result TOBJ_T(tobj_load_obj_from_memory)(
+    TOBJ_T(tobj_scene) * out, const uint8_t *buf, size_t len,
+    const tobj_load_config *cfg, tobj_diag *diag);
+
+#ifdef TOBJ_ENABLE_FILE_IO
+TOBJ_API tobj_result TOBJ_T(tobj_load_obj_from_file)(
+    TOBJ_T(tobj_scene) * out, const char *path, const tobj_load_config *cfg,
+    tobj_diag *diag);
+#endif
+
+TOBJ_API tobj_result TOBJ_T(tobj_load_obj_with_callbacks)(
+    const uint8_t *buf, size_t len, const TOBJ_T(tobj_callbacks) * cb,
+    const tobj_load_config *cfg, tobj_diag *diag);
+
+TOBJ_API void TOBJ_T(tobj_scene_free)(TOBJ_T(tobj_scene) * scene);
+
+TOBJ_API tobj_result TOBJ_T(tobj_parse_mtl_from_memory)(
+    TOBJ_T(tobj_material_list) * out, const uint8_t *buf, size_t len,
+    const tobj_load_config *cfg, tobj_diag *diag);
+
+TOBJ_API void TOBJ_T(tobj_material_list_free)(TOBJ_T(tobj_material_list) * list);
+
+TOBJ_API const char *TOBJ_T(tobj_material_get_param)(
+    const TOBJ_T(tobj_material) * m, const char *key);

--- a/tobj_tess.c
+++ b/tobj_tess.c
@@ -1,0 +1,279 @@
+/*
+ * tobj_tess.c -- robust polygon tessellation (see tobj_tess.h).
+ *
+ * Strategy: project the 3D ring to 2D (Newell normal, bbox fallback), then
+ * triangulate the 2D polygon with a convex fan fast-path or robust ear
+ * clipping. All 2D work is done in double precision regardless of the input
+ * real type. The ear-clip loop is monotone in the number of remaining
+ * vertices (an unconditional force-clip backstop), so it always terminates
+ * and always emits exactly n-2 triangles for n >= 3.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "tobj_tess.h"
+
+/* Relative epsilon for the 2D "is zero area" test (scaled by polygon size). */
+#define TOBJ_TESS_REL 1e-9
+/* Newell-normal degeneracy threshold (relative to coord magnitude^4). */
+#define TOBJ_TESS_REL_N 1e-18
+/* Largest n handled with on-stack scratch when no buffer/allocator is given. */
+#define TOBJ_TESS_STACK_N 64u
+#define TOBJ_TESS_STACK_BYTES 2048u
+
+/* ----------------------------------------------------------------------- */
+/* scratch layout                                                          */
+/* ----------------------------------------------------------------------- */
+
+typedef struct {
+  double *p2d;     /* 2*n */
+  uint32_t *nxt;   /* n */
+  uint32_t *prv;   /* n */
+  uint8_t *reflex; /* (n+7)/8 */
+} tobj_tess_work;
+
+static size_t tobj_tess_align(size_t x, size_t a) {
+  return (x + (a - 1)) & ~(a - 1);
+}
+
+size_t tobj_tess_scratch_size(uint32_t n) {
+  size_t sn = (size_t)n;
+  size_t a = tobj_tess_align(sn * 2u * sizeof(double), 16);
+  size_t b = tobj_tess_align(sn * sizeof(uint32_t), 16);
+  size_t c = tobj_tess_align(sn * sizeof(uint32_t), 16);
+  size_t d = tobj_tess_align((sn + 7u) / 8u, 16);
+  return a + b + c + d;
+}
+
+static int tobj_tess_work_bind(tobj_tess_work *w, void *scratch, size_t size,
+                               uint32_t n) {
+  if (size < tobj_tess_scratch_size(n)) return 0;
+  unsigned char *base = (unsigned char *)scratch;
+  size_t sn = (size_t)n;
+  size_t off = 0;
+  w->p2d = (double *)(base + off);
+  off += tobj_tess_align(sn * 2u * sizeof(double), 16);
+  w->nxt = (uint32_t *)(base + off);
+  off += tobj_tess_align(sn * sizeof(uint32_t), 16);
+  w->prv = (uint32_t *)(base + off);
+  off += tobj_tess_align(sn * sizeof(uint32_t), 16);
+  w->reflex = (uint8_t *)(base + off);
+  return 1;
+}
+
+static void tobj_tess_set_reflex(tobj_tess_work *w, uint32_t i, int v) {
+  if (v)
+    w->reflex[i >> 3] |= (uint8_t)(1u << (i & 7u));
+  else
+    w->reflex[i >> 3] &= (uint8_t)~(1u << (i & 7u));
+}
+static int tobj_tess_is_reflex(tobj_tess_work *w, uint32_t i) {
+  return (w->reflex[i >> 3] >> (i & 7u)) & 1u;
+}
+
+/* ----------------------------------------------------------------------- */
+/* 2D predicates                                                           */
+/* ----------------------------------------------------------------------- */
+
+static double tobj_orient2d(const double *a, const double *b, const double *c) {
+  return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+}
+
+static double tobj_dabs(double x) { return x < 0 ? -x : x; }
+static int tobj_is_finite(double x) { return x == x && tobj_dabs(x) < 1e308; }
+
+/* Strictly-inside test for triangle (a,b,c) wound so that `wind` * area > 0. */
+static int tobj_point_in_tri(const double *p, const double *a, const double *b,
+                             const double *c, double wind, double eps) {
+  double d1 = wind * tobj_orient2d(a, b, p);
+  double d2 = wind * tobj_orient2d(b, c, p);
+  double d3 = wind * tobj_orient2d(c, a, p);
+  return d1 > eps && d2 > eps && d3 > eps;
+}
+
+/* ----------------------------------------------------------------------- */
+/* 2D triangulation core (operates entirely on w->p2d)                     */
+/* ----------------------------------------------------------------------- */
+
+static void tobj_tess_emit(uint32_t *out, uint32_t *k, uint32_t a, uint32_t b,
+                           uint32_t c) {
+  out[*k * 3u + 0u] = a;
+  out[*k * 3u + 1u] = b;
+  out[*k * 3u + 2u] = c;
+  (*k)++;
+}
+
+/* Fan from corner 0; always valid count, used for convex/forced cases. */
+static void tobj_tess_fan(uint32_t n, uint32_t *out, uint32_t *kp) {
+  for (uint32_t k = 1; k + 1 < n; k++) tobj_tess_emit(out, kp, 0, k, k + 1);
+}
+
+static double tobj_tess_scale2d(const double *p2d, uint32_t n) {
+  double m = 0.0;
+  for (uint32_t i = 0; i < n; i++) {
+    double x = tobj_dabs(p2d[2 * i]);
+    double y = tobj_dabs(p2d[2 * i + 1]);
+    if (x > m) m = x;
+    if (y > m) m = y;
+  }
+  return m;
+}
+
+static double tobj_tess_signed_area(const double *p2d, uint32_t n) {
+  double a = 0.0;
+  for (uint32_t i = 0; i < n; i++) {
+    uint32_t j = (i + 1u) % n;
+    a += p2d[2 * i] * p2d[2 * j + 1] - p2d[2 * j] * p2d[2 * i + 1];
+  }
+  return 0.5 * a;
+}
+
+static const double *tobj_tess_pt(tobj_tess_work *w, uint32_t i) {
+  return &w->p2d[2 * i];
+}
+
+/* Recompute and store the reflex flag for active vertex `cur`. */
+static void tobj_tess_update_reflex(tobj_tess_work *w, uint32_t cur,
+                                    double wind, double eps_a) {
+  uint32_t p = w->prv[cur], n = w->nxt[cur];
+  double o = wind * tobj_orient2d(tobj_tess_pt(w, p), tobj_tess_pt(w, cur),
+                                  tobj_tess_pt(w, n));
+  tobj_tess_set_reflex(w, cur, o < -eps_a ? 1 : 0);
+}
+
+/* Triangulate the ring (n>=5) already projected into w->p2d.
+ * Returns OK or DEGENERATE_BESTEFFORT. Always writes n-2 triangles. */
+static tobj_tess_status tobj_tess_run2d(tobj_tess_work *w, uint32_t n,
+                                        uint32_t *out, uint32_t flags) {
+  uint32_t k = 0;
+
+  if (flags & (TOBJ_TESS_FLAG_FORCE_FAN | TOBJ_TESS_FLAG_ASSUME_CONVEX)) {
+    tobj_tess_fan(n, out, &k);
+    return (flags & TOBJ_TESS_FLAG_FORCE_FAN) ? TOBJ_TESS_DEGENERATE_BESTEFFORT
+                                              : TOBJ_TESS_OK;
+  }
+
+  double scale = tobj_tess_scale2d(w->p2d, n);
+  double eps_a = scale * scale * TOBJ_TESS_REL;
+  double area = tobj_tess_signed_area(w->p2d, n);
+  double wind = area < 0 ? -1.0 : 1.0;
+
+  /* Build ring + reflex flags; count reflex vertices. */
+  uint32_t reflex_count = 0;
+  for (uint32_t i = 0; i < n; i++) {
+    w->nxt[i] = (i + 1u) % n;
+    w->prv[i] = (i + n - 1u) % n;
+  }
+  for (uint32_t i = 0; i < n; i++) {
+    double o = wind * tobj_orient2d(tobj_tess_pt(w, w->prv[i]),
+                                    tobj_tess_pt(w, i),
+                                    tobj_tess_pt(w, w->nxt[i]));
+    int rfx = o < -eps_a ? 1 : 0;
+    tobj_tess_set_reflex(w, i, rfx);
+    reflex_count += (uint32_t)rfx;
+  }
+
+  /* Convex (and simple) -> fan fast path. */
+  if (reflex_count == 0) {
+    tobj_tess_fan(n, out, &k);
+    /* near-zero overall area means a degenerate (collinear) polygon */
+    return tobj_dabs(area) <= eps_a ? TOBJ_TESS_DEGENERATE_BESTEFFORT
+                                    : TOBJ_TESS_OK;
+  }
+
+  tobj_tess_status status = TOBJ_TESS_OK;
+  uint32_t remaining = n;
+  uint32_t cur = 0;
+  uint32_t guard = 0;
+  int relax = 0; /* 0,1,2 escalation level */
+
+  while (remaining > 3) {
+    uint32_t prev = w->prv[cur];
+    uint32_t next = w->nxt[cur];
+    const double *pp = tobj_tess_pt(w, prev);
+    const double *pc = tobj_tess_pt(w, cur);
+    const double *pn = tobj_tess_pt(w, next);
+
+    double raw = tobj_orient2d(pp, pc, pn);
+    double o = wind * raw;
+    double eps_scaled = eps_a * (relax == 0 ? 1.0 : (relax == 1 ? 1e3 : 1e12));
+
+    int clip = 0;
+    if (tobj_dabs(raw) <= eps_scaled) {
+      /* collinear / zero-area corner: removable degenerate ear */
+      clip = 1;
+      status = TOBJ_TESS_DEGENERATE_BESTEFFORT;
+    } else if (o > eps_scaled) {
+      /* convex corner: ensure no reflex active vertex lies inside */
+      int blocked = 0;
+      uint32_t r = w->nxt[next];
+      while (r != prev) {
+        if (tobj_tess_is_reflex(w, r) &&
+            tobj_point_in_tri(tobj_tess_pt(w, r), pp, pc, pn, wind,
+                              eps_scaled)) {
+          blocked = 1;
+          break;
+        }
+        r = w->nxt[r];
+      }
+      if (!blocked) clip = 1;
+    }
+
+    if (clip) {
+      tobj_tess_emit(out, &k, prev, cur, next);
+      w->nxt[prev] = next;
+      w->prv[next] = prev;
+      remaining--;
+      tobj_tess_update_reflex(w, prev, wind, eps_a);
+      tobj_tess_update_reflex(w, next, wind, eps_a);
+      cur = next;
+      guard = 0;
+      relax = 0;
+      continue;
+    }
+
+    cur = next;
+    if (++guard > remaining) {
+      if (relax < 2) {
+        relax++;
+        guard = 0;
+      } else {
+        /* backstop: force-clip current corner to guarantee progress */
+        prev = w->prv[cur];
+        next = w->nxt[cur];
+        tobj_tess_emit(out, &k, prev, cur, next);
+        w->nxt[prev] = next;
+        w->prv[next] = prev;
+        remaining--;
+        tobj_tess_update_reflex(w, prev, wind, eps_a);
+        tobj_tess_update_reflex(w, next, wind, eps_a);
+        cur = next;
+        guard = 0;
+        relax = 0;
+        status = TOBJ_TESS_DEGENERATE_BESTEFFORT;
+      }
+    }
+  }
+
+  /* final triangle from the three survivors */
+  uint32_t a = cur;
+  uint32_t b = w->nxt[a];
+  uint32_t c = w->nxt[b];
+  tobj_tess_emit(out, &k, a, b, c);
+  return status;
+}
+
+/* ----------------------------------------------------------------------- */
+/* per-precision wrappers (projection + dispatch)                          */
+/* ----------------------------------------------------------------------- */
+
+#define TOBJ_TESS_REAL float
+#define TOBJ_TESS_SUF _f
+#include "tobj_tess_impl.inc"
+#undef TOBJ_TESS_REAL
+#undef TOBJ_TESS_SUF
+
+#define TOBJ_TESS_REAL double
+#define TOBJ_TESS_SUF _d
+#include "tobj_tess_impl.inc"
+#undef TOBJ_TESS_REAL
+#undef TOBJ_TESS_SUF

--- a/tobj_tess.h
+++ b/tobj_tess.h
@@ -1,0 +1,80 @@
+/*
+ * tobj_tess.h -- robust & fast polygon tessellation for tiny_obj_c.
+ *
+ * Triangulates a single polygon ring (the corner loop of an .obj face),
+ * including pathological / degenerate input: concave, collinear, coincident,
+ * zero-area, non-planar, and self-intersecting polygons. It never crashes or
+ * loops forever and, for any n >= 3, always emits exactly n-2 triangles.
+ *
+ * Output indices are ring-local (0..n-1); the caller maps them back to its
+ * own per-corner attribute records.
+ *
+ * Pure C11, no libc dependency (no malloc, no math.h). Reentrant: all state
+ * lives on the stack or in caller-provided scratch, so it is safe to call
+ * from worker threads concurrently.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef TOBJ_TESS_H_
+#define TOBJ_TESS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum tobj_tess_status {
+  TOBJ_TESS_OK = 0,                 /* clean triangulation */
+  TOBJ_TESS_DEGENERATE_BESTEFFORT,  /* n-2 tris emitted, but input was bad */
+  TOBJ_TESS_INVALID,                /* n<3 / bad args / non-finite: 0 tris */
+  TOBJ_TESS_OOM                     /* needed allocation but none available */
+} tobj_tess_status;
+
+enum {
+  TOBJ_TESS_FLAG_NONE = 0,
+  TOBJ_TESS_FLAG_ASSUME_CONVEX = 1u << 0, /* skip convexity test, fan */
+  TOBJ_TESS_FLAG_FORCE_FAN = 1u << 1,     /* always fan from corner 0 */
+  TOBJ_TESS_FLAG_NORMAL_GIVEN = 1u << 2   /* use desc->normal, skip Newell */
+};
+
+/* Optional allocator (used only when scratch / out_indices are not supplied). */
+typedef struct tobj_tess_allocator {
+  void *(*alloc)(void *ud, size_t size);
+  void (*free)(void *ud, void *ptr);
+  void *ud;
+} tobj_tess_allocator;
+
+/* Worst-case scratch size (in bytes) needed to tessellate n vertices with no
+ * dynamic allocation. Pure function. */
+size_t tobj_tess_scratch_size(uint32_t n);
+
+typedef struct tobj_tess_result {
+  uint32_t *indices;      /* == desc->out_indices, or an allocated block */
+  uint32_t num_triangles; /* n-2 on success */
+  int indices_allocated;  /* 1 => free indices with the allocator */
+  tobj_tess_status status;
+} tobj_tess_result;
+
+#define TOBJ_TESS_CAT_(a, b) a##b
+#define TOBJ_TESS_CAT(a, b) TOBJ_TESS_CAT_(a, b)
+#define TOBJ_TESS_T(name) TOBJ_TESS_CAT(name, TOBJ_TESS_SUF)
+
+#define TOBJ_TESS_REAL float
+#define TOBJ_TESS_SUF _f
+#include "tobj_tess_pub.inc"
+#undef TOBJ_TESS_REAL
+#undef TOBJ_TESS_SUF
+
+#define TOBJ_TESS_REAL double
+#define TOBJ_TESS_SUF _d
+#include "tobj_tess_pub.inc"
+#undef TOBJ_TESS_REAL
+#undef TOBJ_TESS_SUF
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TOBJ_TESS_H_ */

--- a/tobj_tess_impl.inc
+++ b/tobj_tess_impl.inc
@@ -1,0 +1,223 @@
+/*
+ * tobj_tess_impl.inc -- per-precision projection + dispatch.
+ * Included twice from tobj_tess.c. Do not include directly.
+ */
+
+/* Project the 3D ring into w->p2d (double). Returns 1 normally, 0 if the
+ * polygon is fully degenerate (collinear/zero-area) and a bbox fallback was
+ * used. Never fails. */
+static int TOBJ_TESS_T(tobj_tess_project)(const TOBJ_TESS_REAL *pts, uint32_t n,
+                                          const TOBJ_TESS_REAL *given_normal,
+                                          uint32_t flags, tobj_tess_work *w) {
+  double cx = (double)pts[0], cy = (double)pts[1], cz = (double)pts[2];
+  double coordmax = 0.0;
+  for (uint32_t i = 0; i < 3u * n; i++) {
+    double a = tobj_dabs((double)pts[i]);
+    if (a > coordmax) coordmax = a;
+  }
+
+  double nx = 0, ny = 0, nz = 0;
+  if (flags & TOBJ_TESS_FLAG_NORMAL_GIVEN) {
+    nx = (double)given_normal[0];
+    ny = (double)given_normal[1];
+    nz = (double)given_normal[2];
+  } else {
+    for (uint32_t k = 0; k < n; k++) {
+      uint32_t j = (k + 1u) % n;
+      double ax = (double)pts[3 * k], ay = (double)pts[3 * k + 1],
+             az = (double)pts[3 * k + 2];
+      double bx = (double)pts[3 * j], by = (double)pts[3 * j + 1],
+             bz = (double)pts[3 * j + 2];
+      nx += (ay - by) * (az + bz);
+      ny += (az - bz) * (ax + bx);
+      nz += (ax - bx) * (ay + by);
+    }
+  }
+  double len2 = nx * nx + ny * ny + nz * nz;
+  double cm2 = coordmax * coordmax;
+  double thresh = cm2 * cm2 * TOBJ_TESS_REL_N;
+
+  if (tobj_is_finite(len2) && len2 > thresh && len2 > 0.0) {
+    /* in-plane basis (unnormalized: only orientation signs matter) */
+    double wx = nx, wy = ny, wz = nz;
+    double ax = tobj_dabs(wx), ay = tobj_dabs(wy), az = tobj_dabs(wz);
+    double sx = 0, sy = 0, sz = 0;
+    if (ax <= ay && ax <= az)
+      sx = 1;
+    else if (ay <= az)
+      sy = 1;
+    else
+      sz = 1;
+    /* u = w x s, v = w x u */
+    double ux = wy * sz - wz * sy;
+    double uy = wz * sx - wx * sz;
+    double uz = wx * sy - wy * sx;
+    double vx = wy * uz - wz * uy;
+    double vy = wz * ux - wx * uz;
+    double vz = wx * uy - wy * ux;
+    for (uint32_t k = 0; k < n; k++) {
+      double dx = (double)pts[3 * k] - cx;
+      double dy = (double)pts[3 * k + 1] - cy;
+      double dz = (double)pts[3 * k + 2] - cz;
+      w->p2d[2 * k] = dx * ux + dy * uy + dz * uz;
+      w->p2d[2 * k + 1] = dx * vx + dy * vy + dz * vz;
+    }
+    return 1;
+  }
+
+  /* Fallback: drop the smallest-extent axis, keep the other two raw axes. */
+  double mn[3], mx[3];
+  mn[0] = mx[0] = (double)pts[0];
+  mn[1] = mx[1] = (double)pts[1];
+  mn[2] = mx[2] = (double)pts[2];
+  for (uint32_t k = 0; k < n; k++) {
+    for (int c = 0; c < 3; c++) {
+      double v = (double)pts[3 * k + c];
+      if (v < mn[c]) mn[c] = v;
+      if (v > mx[c]) mx[c] = v;
+    }
+  }
+  double span[3] = {mx[0] - mn[0], mx[1] - mn[1], mx[2] - mn[2]};
+  int drop = 0;
+  if (span[1] < span[0]) drop = 1;
+  if (span[2] < span[drop]) drop = 2;
+  int a0 = (drop == 0) ? 1 : 0;
+  int a1 = (drop == 2) ? 1 : 2;
+  for (uint32_t k = 0; k < n; k++) {
+    w->p2d[2 * k] = (double)pts[3 * k + a0] - (drop == 0 ? cy : cx);
+    w->p2d[2 * k + 1] =
+        (double)pts[3 * k + a1] - ((drop == 2) ? cy : cz);
+  }
+  return 0;
+}
+
+tobj_tess_status TOBJ_TESS_T(tobj_tess_polygon)(
+    const TOBJ_TESS_T(tobj_tess_desc) * desc, tobj_tess_result *result) {
+  result->indices = NULL;
+  result->num_triangles = 0;
+  result->indices_allocated = 0;
+  result->status = TOBJ_TESS_INVALID;
+
+  if (!desc || !desc->points) return TOBJ_TESS_INVALID;
+  uint32_t n = desc->n;
+  if (n < 3) return TOBJ_TESS_INVALID;
+
+  /* reject non-finite coordinates */
+  for (uint32_t i = 0; i < 3u * n; i++) {
+    if (!tobj_is_finite((double)desc->points[i])) return TOBJ_TESS_INVALID;
+  }
+
+  uint32_t tri = n - 2u;
+  uint32_t need_out = tri * 3u;
+
+  /* resolve output buffer */
+  uint32_t *out = NULL;
+  int out_alloc = 0;
+  if (desc->out_indices && desc->out_cap >= need_out) {
+    out = desc->out_indices;
+  } else if (desc->alloc && desc->alloc->alloc) {
+    out = (uint32_t *)desc->alloc->alloc(desc->alloc->ud,
+                                         need_out * sizeof(uint32_t));
+    if (!out) {
+      result->status = TOBJ_TESS_OOM;
+      return TOBJ_TESS_OOM;
+    }
+    out_alloc = 1;
+  } else {
+    result->status = TOBJ_TESS_OOM;
+    return TOBJ_TESS_OOM;
+  }
+
+  /* resolve scratch */
+  size_t need_scratch = tobj_tess_scratch_size(n);
+  void *scratch = NULL;
+  int scratch_alloc = 0;
+  unsigned char stackbuf[TOBJ_TESS_STACK_BYTES];
+  if (desc->scratch && desc->scratch_size >= need_scratch) {
+    scratch = desc->scratch;
+  } else if (n <= TOBJ_TESS_STACK_N && need_scratch <= sizeof(stackbuf)) {
+    scratch = stackbuf;
+  } else if (desc->alloc && desc->alloc->alloc) {
+    scratch = desc->alloc->alloc(desc->alloc->ud, need_scratch);
+    if (!scratch) {
+      if (out_alloc) desc->alloc->free(desc->alloc->ud, out);
+      result->status = TOBJ_TESS_OOM;
+      return TOBJ_TESS_OOM;
+    }
+    scratch_alloc = 1;
+  } else {
+    if (out_alloc && desc->alloc) desc->alloc->free(desc->alloc->ud, out);
+    result->status = TOBJ_TESS_OOM;
+    return TOBJ_TESS_OOM;
+  }
+
+  tobj_tess_work w;
+  tobj_tess_work_bind(&w, scratch, need_scratch, n);
+
+  int proj_ok =
+      TOBJ_TESS_T(tobj_tess_project)(desc->points, n, desc->normal,
+                                     desc->flags, &w);
+
+  tobj_tess_status status;
+  uint32_t k = 0;
+
+  if (n == 3) {
+    tobj_tess_emit(out, &k, 0, 1, 2);
+    double ar = tobj_dabs(tobj_orient2d(&w.p2d[0], &w.p2d[2], &w.p2d[4]));
+    double scale = tobj_tess_scale2d(w.p2d, n);
+    status = ar <= scale * scale * TOBJ_TESS_REL ? TOBJ_TESS_DEGENERATE_BESTEFFORT
+                                                 : TOBJ_TESS_OK;
+  } else if (n == 4) {
+    double scale = tobj_tess_scale2d(w.p2d, n);
+    double eps = scale * scale * TOBJ_TESS_REL;
+    const double *p0 = &w.p2d[0], *p1 = &w.p2d[2], *p2 = &w.p2d[4],
+                 *p3 = &w.p2d[6];
+    double o012 = tobj_orient2d(p0, p1, p2);
+    double o023 = tobj_orient2d(p0, p2, p3);
+    double o123 = tobj_orient2d(p1, p2, p3);
+    double o130 = tobj_orient2d(p1, p3, p0);
+    int d02 = (tobj_dabs(o012) > eps && tobj_dabs(o023) > eps &&
+               ((o012 > 0) == (o023 > 0)));
+    int d13 = (tobj_dabs(o123) > eps && tobj_dabs(o130) > eps &&
+               ((o123 > 0) == (o130 > 0)));
+    int split02;
+    status = TOBJ_TESS_OK;
+    if (d02 && !d13) {
+      split02 = 1;
+    } else if (d13 && !d02) {
+      split02 = 0;
+    } else {
+      /* convex (both internal) or degenerate (neither): shorter 3D diagonal */
+      const TOBJ_TESS_REAL *q = desc->points;
+      double e02x = (double)q[6] - (double)q[0];
+      double e02y = (double)q[7] - (double)q[1];
+      double e02z = (double)q[8] - (double)q[2];
+      double e13x = (double)q[9] - (double)q[3];
+      double e13y = (double)q[10] - (double)q[4];
+      double e13z = (double)q[11] - (double)q[5];
+      double s02 = e02x * e02x + e02y * e02y + e02z * e02z;
+      double s13 = e13x * e13x + e13y * e13y + e13z * e13z;
+      split02 = s02 <= s13;
+      if (!d02 && !d13) status = TOBJ_TESS_DEGENERATE_BESTEFFORT;
+    }
+    if (split02) {
+      tobj_tess_emit(out, &k, 0, 1, 2);
+      tobj_tess_emit(out, &k, 0, 2, 3);
+    } else {
+      tobj_tess_emit(out, &k, 0, 1, 3);
+      tobj_tess_emit(out, &k, 1, 2, 3);
+    }
+  } else {
+    status = tobj_tess_run2d(&w, n, out, desc->flags);
+  }
+
+  if (!proj_ok && status == TOBJ_TESS_OK) status = TOBJ_TESS_DEGENERATE_BESTEFFORT;
+
+  if (scratch_alloc) desc->alloc->free(desc->alloc->ud, scratch);
+
+  result->indices = out;
+  result->num_triangles = tri;
+  result->indices_allocated = out_alloc;
+  result->status = status;
+  return status;
+}

--- a/tobj_tess_pub.inc
+++ b/tobj_tess_pub.inc
@@ -1,0 +1,23 @@
+/*
+ * tobj_tess_pub.inc -- per-precision tessellation descriptor + entry point.
+ * Included twice from tobj_tess.h. Do not include directly.
+ */
+
+typedef struct TOBJ_TESS_T(tobj_tess_desc) {
+  const TOBJ_TESS_REAL *points; /* n*3 xyz, stride 3 */
+  uint32_t n;
+  const TOBJ_TESS_REAL *normal; /* [3]; used iff FLAG_NORMAL_GIVEN */
+  uint32_t flags;
+
+  uint32_t *out_indices; /* caller buffer; cap >= 3*(n-2), or NULL to alloc */
+  uint32_t out_cap;      /* capacity of out_indices in uint32 units */
+
+  void *scratch;       /* >= tobj_tess_scratch_size(n), or NULL to alloc */
+  size_t scratch_size; /* size of scratch in bytes */
+
+  const tobj_tess_allocator *alloc; /* used only when buffers are missing */
+} TOBJ_TESS_T(tobj_tess_desc);
+
+/* Triangulate one polygon ring. Never crashes/loops for n >= 3. */
+tobj_tess_status TOBJ_TESS_T(tobj_tess_polygon)(
+    const TOBJ_TESS_T(tobj_tess_desc) * desc, tobj_tess_result *result);


### PR DESCRIPTION
## Summary

A from-scratch **pure C11** reimplementation of tinyobjloader: secure, portable, freestanding-capable, dependency-free, fast, and robust. Not header-only — `tiny_obj_c.c` + `tiny_obj_c.h`, plus a separate reusable tessellation library `tobj_tess.{c,h}`. Carries the C++ feature set over to C11 and adds line/point/free-form-patch primitives.

## Highlights

- **Dual precision** — float (`_f`) and double (`_d`) families coexist in one build, generated from a single template via token-pasting.
- **Freestanding / no-dependency** — the core links **zero libc symbols** (verified with `nm` under `-ffreestanding -DTOBJ_NO_LIBC`): no malloc/strtod/fopen/memcpy/sqrt/pthread. Injectable allocator, bundled ASCII→float parser, no `math.h` in the core or default tessellator.
- **Robust tessellation** (`tobj_tess`) — Newell projection with bbox fallback, magnitude-scaled epsilons (fixes the C++ absolute-`epsilon` area threshold that is meaningless at the ~8000–14000 coordinate magnitudes in `sandbox/zh2-ill.obj`, `sandbox/ill-tri.obj`, `models/issue-295-trianguation-failure.obj`), a convex fan fast path, and a force-clip backstop that **always emits n−2 triangles and never crashes or loops** on degenerate, concave, collinear, coincident, non-planar, or self-intersecting input.
- **Primitives** — faces (triangulated), lines (`l`), points (`p`), and **free-form patches** (`cstype`/`curv`/`curv2`/`surf`/`vp`/`parm`/`trim`/`hole`/`end`) parsed and retained losslessly (no NURBS evaluation).
- **Full material support** — Phong + PBR + 13 texture channels with options, unknown-parameter map, `map_Kd`-without-`Kd` default, standalone `.mtl` API, material-resolver callback (replaces the virtual `MaterialReader`), and a streaming callback API.
- **Optional perf behind macros** (scalar/single-threaded/libc default) — multithreaded two-pass parse, SIMD newline scan (AVX2/SSE2/NEON), mmap + file I/O, arena allocator, fast float.
- **Security** — bounds-checked indices, overflow-safe size arithmetic, configurable caps, defined teardown.

## Validation (all under ASan + UBSan)

- 84-file corpus (`models/` + `sandbox/`) loads with **0 failures**, 1.45M triangles, consistent index counts.
- acutest drivers: `tests/tess_tester.c` (15 unit/property tests incl. pathological classes, area preservation, determinism) and `tests/tester_c.c` (12 loader tests: corpus, both precisions, triangulation, BOM/CRLF, vertex colors, lines/points, MTL, garbage) — all pass.
- Freestanding driver runs with a custom bump allocator and no libc.
- **Multithreaded output is byte-identical to single-threaded** on a 20k-vertex varied OBJ.
- libFuzzer harness finds no crashes/leaks.
- Strict `-Wall -Wextra -Wpedantic -Wshadow` clean (default and all-features).

## Build / test

```
cd tests && make check_c          # tester_c, tester_c_features (SIMD+MT), tess_tester, freestanding
# or via CMake:
cmake -S . -B build -DTINYOBJLOADER_C_BUILD_TESTS=ON && cmake --build build && ctest --test-dir build
```

Added options in `CMakeLists.txt`: `TINYOBJLOADER_BUILD_C_LIBRARY` (ON), `TINYOBJLOADER_C_ENABLE_FILE_IO`/`MMAP`/`SIMD`/`MULTITHREADING`, `TINYOBJLOADER_C_BUILD_TESTS`, plus a `fuzz_tobj_c` target under `LIB_FUZZING_ENGINE`.

## Known limitation

In the multithreaded path, `curv2`→`vp` index resolution can differ from single-threaded **only** when `vp` lines have inconsistent component counts (a pathological free-form case); it does not affect the corpus or normal use. A reserved `tobj_mathops` hook is currently unused (the default tessellator needs no `sqrt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)