### PR TITLE
Harden C11 allocator and IO callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,11 @@ Properties:
   (no `malloc` / `stdio` / `strtod` / `math.h`): supply your own allocator and a
   byte buffer. Define `TOBJ_NO_LIBC` (a.k.a. `TOBJ_FREESTANDING`) for that mode,
   or enable libc-backed conveniences with `TOBJ_ENABLE_FILE_IO`.
+* **Pluggable allocation and I/O.** `tobj_allocator` carries bounded
+  size/alignment requests (`max_alloc_size` is optional) and supports custom
+  `alloc`/`calloc`/`free` backends; libc builds default to malloc/calloc/free.
+  `tobj_load_obj_from_io_*` reads through caller-supplied byte callbacks for
+  freestanding streams.
 * **Dual precision.** `float` (`_f`) and `double` (`_d`) data structures and
   entry points coexist in the same build (e.g. `tobj_scene_f` / `tobj_scene_d`).
 * **Robust tessellation.** Survives degenerate / concave / collinear /
@@ -456,10 +461,11 @@ tobj_diag_free(&diag, NULL);
 ```
 
 Use the `_d` variants for double precision, `tobj_load_obj_from_memory_f` for
-the freestanding / in-memory path, and `tobj_load_obj_with_callbacks_f` for
-streaming. Build with CMake (`-DTINYOBJLOADER_BUILD_C_LIBRARY=ON`, the default;
-options `TINYOBJLOADER_C_ENABLE_FILE_IO` / `MMAP` / `SIMD` / `MULTITHREADING`)
-or simply compile `tiny_obj_c.c` and `tobj_tess.c`. C tests live under `tests/`
+the freestanding / in-memory path, `tobj_load_obj_from_io_f` for custom byte
+input, and `tobj_load_obj_with_callbacks_f` for parse-event callbacks. Build
+with CMake (`-DTINYOBJLOADER_BUILD_C_LIBRARY=ON`, the default; options
+`TINYOBJLOADER_C_ENABLE_FILE_IO` / `MMAP` / `SIMD` / `MULTITHREADING`) or simply
+compile `tiny_obj_c.c` and `tobj_tess.c`. C tests live under `tests/`
 (`make check_c`).
 
 ## Python binding

--- a/tests/tester_c.c
+++ b/tests/tester_c.c
@@ -42,9 +42,48 @@ static const char *load_string_f(const char *obj, tobj_scene_f *sc,
   return tobj_result_string(r);
 }
 
+typedef struct mem_io {
+  const uint8_t *data;
+  size_t len;
+  size_t pos;
+  size_t chunk;
+  int closed;
+} mem_io;
+
+static tobj_result mem_io_read(void *ud, uint8_t *dst, size_t dst_size,
+                               size_t *bytes_read) {
+  mem_io *m = (mem_io *)ud;
+  size_t left = m->len - m->pos;
+  size_t n = left < dst_size ? left : dst_size;
+  if (m->chunk && n > m->chunk) n = m->chunk;
+  if (n) memcpy(dst, m->data + m->pos, n);
+  m->pos += n;
+  *bytes_read = n;
+  return TOBJ_OK;
+}
+
+static void mem_io_close(void *ud) { ((mem_io *)ud)->closed = 1; }
+
+static tobj_result io_overreport_read(void *ud, uint8_t *dst, size_t dst_size,
+                                      size_t *bytes_read) {
+  (void)ud;
+  if (dst_size) dst[0] = 'x';
+  *bytes_read = dst_size + 1;
+  return TOBJ_OK;
+}
+
+static tobj_result io_error_read(void *ud, uint8_t *dst, size_t dst_size,
+                                 size_t *bytes_read) {
+  (void)ud;
+  (void)dst;
+  (void)dst_size;
+  *bytes_read = 0;
+  return TOBJ_ERR_IO;
+}
+
 /* ---- corpus ------------------------------------------------------------ */
 
-/* Only files committed to the repo (CI checks out a clean tree; sandbox/*.obj
+/* Only files committed to the repo (CI checks out a clean tree; sandbox files
  * are local scratch files and are intentionally not used here). The
  * pathological-geometry triangulation cases are covered directly by
  * tests/tess_tester.c. */
@@ -205,6 +244,143 @@ static void test_mtl_standalone(void) {
   tobj_material_list_free_f(&ml);
 }
 
+static void test_io_callbacks(void) {
+  const char *obj = "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n";
+  mem_io mio;
+  mio.data = (const uint8_t *)obj;
+  mio.len = strlen(obj);
+  mio.pos = 0;
+  mio.chunk = 5;
+  mio.closed = 0;
+  tobj_io_callbacks io;
+  io.read = mem_io_read;
+  io.close = mem_io_close;
+  io.user_data = &mio;
+  tobj_load_config cfg = tobj_default_config();
+  tobj_scene_f sc;
+  tobj_result r = tobj_load_obj_from_io_f(&sc, &io, &cfg, NULL);
+  TEST_CHECK(r == TOBJ_OK);
+  TEST_CHECK(mio.closed == 1);
+  TEST_CHECK(sc.num_shapes == 1);
+  TEST_CHECK(sc.shapes[0].mesh.num_indices == 3);
+  tobj_scene_free_f(&sc);
+}
+
+static void test_allocator_limit_failure(void) {
+  const char *obj = "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n";
+  tobj_load_config cfg = tobj_default_config();
+  cfg.allocator = tobj_default_allocator();
+  cfg.allocator.max_alloc_size = 16;
+  tobj_scene_f sc;
+  tobj_result r =
+      tobj_load_obj_from_memory_f(&sc, (const uint8_t *)obj, strlen(obj), &cfg,
+                                  NULL);
+  TEST_CHECK(r == TOBJ_ERR_ALLOC);
+  TEST_CHECK(sc.num_shapes == 0);
+}
+
+static void test_input_limit_failure(void) {
+  const char *obj = "v 0 0 0\n";
+  tobj_load_config cfg = tobj_default_config();
+  cfg.max_input_bytes = 4;
+  tobj_scene_f sc;
+  tobj_result r =
+      tobj_load_obj_from_memory_f(&sc, (const uint8_t *)obj, strlen(obj), &cfg,
+                                  NULL);
+  TEST_CHECK(r == TOBJ_ERR_LIMIT_EXCEEDED);
+}
+
+static void test_io_input_limit_exact_and_over(void) {
+  const char *obj = "v 0 0 0\n";
+  tobj_load_config cfg = tobj_default_config();
+  cfg.max_input_bytes = strlen(obj);
+
+  mem_io exact;
+  exact.data = (const uint8_t *)obj;
+  exact.len = strlen(obj);
+  exact.pos = 0;
+  exact.chunk = 3;
+  exact.closed = 0;
+  tobj_io_callbacks io;
+  io.read = mem_io_read;
+  io.close = mem_io_close;
+  io.user_data = &exact;
+  tobj_scene_f sc;
+  tobj_result r = tobj_load_obj_from_io_f(&sc, &io, &cfg, NULL);
+  TEST_CHECK(r == TOBJ_OK);
+  TEST_CHECK(exact.closed == 1);
+  tobj_scene_free_f(&sc);
+
+  const char *too_big = "v 0 0 0\n# extra\n";
+  mem_io over;
+  over.data = (const uint8_t *)too_big;
+  over.len = strlen(too_big);
+  over.pos = 0;
+  over.chunk = 0;
+  over.closed = 0;
+  io.user_data = &over;
+  r = tobj_load_obj_from_io_f(&sc, &io, &cfg, NULL);
+  TEST_CHECK(r == TOBJ_ERR_LIMIT_EXCEEDED);
+  TEST_CHECK(over.closed == 1);
+  TEST_CHECK(sc.num_shapes == 0);
+}
+
+static void test_io_callback_errors(void) {
+  tobj_io_callbacks io;
+  io.close = mem_io_close;
+
+  mem_io state;
+  state.data = NULL;
+  state.len = 0;
+  state.pos = 0;
+  state.chunk = 0;
+  state.closed = 0;
+  io.user_data = &state;
+  io.read = io_overreport_read;
+  tobj_scene_f sc;
+  tobj_result r = tobj_load_obj_from_io_f(&sc, &io, NULL, NULL);
+  TEST_CHECK(r == TOBJ_ERR_IO);
+  TEST_CHECK(state.closed == 1);
+
+  state.closed = 0;
+  io.read = io_error_read;
+  r = tobj_load_obj_from_io_f(&sc, &io, NULL, NULL);
+  TEST_CHECK(r == TOBJ_ERR_IO);
+  TEST_CHECK(state.closed == 1);
+}
+
+static void test_invalid_allocator_rejected(void) {
+  const char *obj = "v 0 0 0\n";
+  tobj_load_config cfg = tobj_default_config();
+  cfg.allocator = tobj_default_allocator();
+  cfg.allocator.free = NULL;
+  tobj_scene_f sc;
+  tobj_result r =
+      tobj_load_obj_from_memory_f(&sc, (const uint8_t *)obj, strlen(obj), &cfg,
+                                  NULL);
+  TEST_CHECK(r == TOBJ_ERR_INVALID_ARG);
+  TEST_CHECK(sc.num_shapes == 0);
+}
+
+static void test_allocator_without_calloc_or_realloc(void) {
+  const char *obj =
+      "v 0 0 0\nv 1 0 0\nv 2 0 0\nv 3 0 0\nv 4 0 0\n"
+      "v 5 0 0\nv 6 0 0\nv 7 0 0\nv 8 0 0\n"
+      "f 1 2 3\nf 4 5 6\nf 7 8 9\n";
+  tobj_load_config cfg = tobj_default_config();
+  cfg.allocator = tobj_default_allocator();
+  cfg.allocator.calloc = NULL;
+  cfg.allocator.realloc = NULL;
+  tobj_scene_f sc;
+  tobj_result r =
+      tobj_load_obj_from_memory_f(&sc, (const uint8_t *)obj, strlen(obj), &cfg,
+                                  NULL);
+  TEST_CHECK(r == TOBJ_OK);
+  TEST_CHECK(sc.attrib.vertices.count == 27);
+  TEST_CHECK(sc.shapes[0].mesh.num_indices == 9);
+  tobj_scene_free_f(&sc);
+}
+
 TEST_LIST = {
     {"corpus_loads", test_corpus_loads},
     {"both_precisions", test_both_precisions},
@@ -218,4 +394,12 @@ TEST_LIST = {
     {"degenerate_face_skipped", test_degenerate_face_skipped},
     {"empty_and_garbage", test_empty_and_garbage},
     {"mtl_standalone", test_mtl_standalone},
+    {"io_callbacks", test_io_callbacks},
+    {"allocator_limit_failure", test_allocator_limit_failure},
+    {"input_limit_failure", test_input_limit_failure},
+    {"io_input_limit_exact_and_over", test_io_input_limit_exact_and_over},
+    {"io_callback_errors", test_io_callback_errors},
+    {"invalid_allocator_rejected", test_invalid_allocator_rejected},
+    {"allocator_without_calloc_or_realloc",
+     test_allocator_without_calloc_or_realloc},
     {NULL, NULL}};

--- a/tests/tester_c_freestanding.c
+++ b/tests/tester_c_freestanding.c
@@ -41,8 +41,10 @@ static const char g_obj[] =
 int main(void) {
   tobj_allocator a;
   a.alloc = fs_alloc;
+  a.calloc = 0;
   a.realloc = fs_realloc;
   a.free = fs_free;
+  a.max_alloc_size = 0;
   a.user_data = (void *)0;
 
   tobj_load_config cfg = tobj_default_config();

--- a/tiny_obj_c.c
+++ b/tiny_obj_c.c
@@ -19,7 +19,7 @@
 #include "tiny_obj_c.h"
 
 #ifndef TOBJ_NO_LIBC
-#include <stdlib.h> /* malloc/realloc/free */
+#include <stdlib.h> /* malloc/calloc/free */
 #endif
 
 #include <float.h>
@@ -116,12 +116,11 @@ static void *tobj_libc_alloc(void *ud, size_t size, size_t align) {
   (void)align; /* malloc already returns max_align_t-aligned storage */
   return malloc(size ? size : 1);
 }
-static void *tobj_libc_realloc(void *ud, void *ptr, size_t old_size,
-                               size_t new_size, size_t align) {
+static void *tobj_libc_calloc(void *ud, size_t count, size_t size,
+                              size_t align) {
   (void)ud;
-  (void)old_size;
-  (void)align;
-  return realloc(ptr, new_size ? new_size : 1);
+  (void)align; /* calloc already returns max_align_t-aligned storage */
+  return calloc(count ? count : 1, size ? size : 1);
 }
 static void tobj_libc_free(void *ud, void *ptr, size_t size) {
   (void)ud;
@@ -131,22 +130,77 @@ static void tobj_libc_free(void *ud, void *ptr, size_t size) {
 tobj_allocator tobj_default_allocator(void) {
   tobj_allocator a;
   a.alloc = tobj_libc_alloc;
-  a.realloc = tobj_libc_realloc;
+  a.calloc = tobj_libc_calloc;
+  a.realloc = NULL;
   a.free = tobj_libc_free;
+  a.max_alloc_size = 0;
   a.user_data = NULL;
   return a;
 }
 #endif
 
+static bool tobj_is_pow2(size_t x) { return x && ((x & (x - 1u)) == 0); }
+
+static bool tobj_allocator_valid(const tobj_allocator *a) {
+  return a && a->alloc && a->free;
+}
+
+static bool tobj_resolve_allocator(const tobj_allocator *src,
+                                   tobj_allocator *out) {
+  if (src && src->alloc) {
+    if (!tobj_allocator_valid(src)) return false;
+    *out = *src;
+    return true;
+  }
+#ifndef TOBJ_NO_LIBC
+  *out = tobj_default_allocator();
+  return true;
+#else
+  (void)out;
+  return false;
+#endif
+}
+
+static bool tobj_alloc_request_valid(const tobj_allocator *a, size_t size,
+                                     size_t align) {
+  if (!tobj_allocator_valid(a)) return false;
+  if (!tobj_is_pow2(align)) return false;
+  if (a->max_alloc_size && size > a->max_alloc_size) return false;
+  return true;
+}
+
 static void *tobj_alloc(const tobj_allocator *a, size_t size, size_t align) {
+  if (size == 0) size = 1;
+  if (!tobj_alloc_request_valid(a, size, align)) return NULL;
   return a->alloc(a->user_data, size, align);
 }
+static void *tobj_calloc(const tobj_allocator *a, size_t count, size_t size,
+                         size_t align) {
+  size_t bytes;
+  if (!tobj_size_mul(count ? count : 1, size ? size : 1, &bytes)) return NULL;
+  if (!tobj_alloc_request_valid(a, bytes, align)) return NULL;
+  if (a->calloc) return a->calloc(a->user_data, count, size, align);
+  void *p = a->alloc(a->user_data, bytes, align);
+  if (p) tobj_memset(p, 0, bytes);
+  return p;
+}
 static void tobj_free(const tobj_allocator *a, void *ptr, size_t size) {
-  if (ptr) a->free(a->user_data, ptr, size);
+  if (ptr && tobj_allocator_valid(a)) a->free(a->user_data, ptr, size);
 }
 static void *tobj_realloc(const tobj_allocator *a, void *ptr, size_t old_size,
                           size_t new_size, size_t align) {
-  return a->realloc(a->user_data, ptr, old_size, new_size, align);
+  if (new_size == 0) new_size = 1;
+  if (!tobj_alloc_request_valid(a, new_size, align)) return NULL;
+  if (a->realloc)
+    return a->realloc(a->user_data, ptr, old_size, new_size, align);
+  void *p = tobj_alloc(a, new_size, align);
+  if (!p) return NULL;
+  if (ptr && old_size) {
+    size_t n = old_size < new_size ? old_size : new_size;
+    tobj_memcpy(p, ptr, n);
+    tobj_free(a, ptr, old_size);
+  }
+  return p;
 }
 
 /* Arena: bump allocator over a linked list of blocks. Never frees one
@@ -270,7 +324,12 @@ static bool tobj_vec_reserve(tobj_vec *v, size_t want, const tobj_allocator *a) 
   size_t old_bytes, new_bytes;
   if (!tobj_size_mul(v->cap, v->elem, &old_bytes)) return false;
   if (!tobj_size_mul(newcap, v->elem, &new_bytes)) return false;
-  void *p = tobj_realloc(a, v->data, old_bytes, new_bytes, 16);
+  void *p = NULL;
+  if (v->data) {
+    p = tobj_realloc(a, v->data, old_bytes, new_bytes, 16);
+  } else {
+    p = tobj_calloc(a, newcap, v->elem, 16);
+  }
   if (!p) return false;
   v->data = p;
   v->cap = newcap;
@@ -676,6 +735,7 @@ typedef struct tobj_pending_kv {
 /* Resolve effective caps (0 => built-in default). */
 typedef struct tobj_caps {
   size_t vertices, indices, faces, arity, materials, shapes, line_bytes;
+  size_t input_bytes;
 } tobj_caps;
 
 static tobj_caps tobj_resolve_caps(const tobj_load_config *cfg) {
@@ -688,6 +748,7 @@ static tobj_caps tobj_resolve_caps(const tobj_load_config *cfg) {
   c.materials = cfg->max_materials ? cfg->max_materials : (size_t)(1u << 24);
   c.shapes = cfg->max_shapes ? cfg->max_shapes : (size_t)(1u << 24);
   c.line_bytes = cfg->max_line_bytes ? cfg->max_line_bytes : (size_t)(1u << 24);
+  c.input_bytes = cfg->max_input_bytes ? cfg->max_input_bytes : big;
   return c;
 }
 
@@ -712,7 +773,8 @@ typedef struct tobj_file_buf {
 } tobj_file_buf;
 
 static tobj_result tobj_file_open(tobj_file_buf *fb, const char *path,
-                                  const tobj_allocator *a) {
+                                  const tobj_allocator *a,
+                                  size_t max_len) {
   fb->data = NULL;
   fb->len = 0;
   fb->mode = 0;
@@ -725,6 +787,10 @@ static tobj_result tobj_file_open(tobj_file_buf *fb, const char *path,
       struct stat st;
       if (fstat(fd, &st) == 0 && st.st_size >= 0) {
         size_t sz = (size_t)st.st_size;
+        if (sz > max_len) {
+          close(fd);
+          return TOBJ_ERR_LIMIT_EXCEEDED;
+        }
         if (sz == 0) {
           close(fd);
           fb->data = (const uint8_t *)"";
@@ -760,6 +826,10 @@ static tobj_result tobj_file_open(tobj_file_buf *fb, const char *path,
       fclose(f);
       return TOBJ_ERR_IO;
     }
+    if ((size_t)sz > max_len) {
+      fclose(f);
+      return TOBJ_ERR_LIMIT_EXCEEDED;
+    }
     if (fseek(f, 0, SEEK_SET) != 0) {
       fclose(f);
       return TOBJ_ERR_IO;
@@ -794,6 +864,7 @@ static void tobj_file_close(tobj_file_buf *fb) {
 typedef struct tobj_file_res_ctx {
   const char *basedir;
   tobj_allocator alloc;
+  size_t max_bytes;
 } tobj_file_res_ctx;
 
 static void tobj_file_release(void *ud, const uint8_t *d, size_t n) {
@@ -825,7 +896,7 @@ static tobj_result tobj_file_material_resolver(void *ud, const char *name,
     tobj_free(&ctx->alloc, path, plen);
     return TOBJ_ERR_ALLOC;
   }
-  tobj_result r = tobj_file_open(fb, path, &ctx->alloc);
+  tobj_result r = tobj_file_open(fb, path, &ctx->alloc, ctx->max_bytes);
   tobj_free(&ctx->alloc, path, plen);
   if (r != TOBJ_OK) {
     tobj_free(&ctx->alloc, fb, sizeof *fb);

--- a/tiny_obj_c.h
+++ b/tiny_obj_c.h
@@ -78,12 +78,15 @@ typedef enum tobj_severity {
 
 /* Injectable allocator. If a config's allocator.alloc is NULL the default
  * libc allocator is used (only available when !TOBJ_NO_LIBC). `align` is a
- * power of two; realloc receives the previous size for arenas/bookkeeping. */
+ * power of two. calloc/realloc are optional; alloc and free are required for
+ * custom allocators. max_alloc_size == 0 means "unbounded". */
 typedef struct tobj_allocator {
   void *(*alloc)(void *ud, size_t size, size_t align);
+  void *(*calloc)(void *ud, size_t count, size_t size, size_t align);
   void *(*realloc)(void *ud, void *ptr, size_t old_size, size_t new_size,
                    size_t align);
   void (*free)(void *ud, void *ptr, size_t size);
+  size_t max_alloc_size;
   void *user_data;
 } tobj_allocator;
 
@@ -156,6 +159,15 @@ typedef struct tobj_mtl_source {
 typedef tobj_result (*tobj_material_resolver)(void *ud, const char *mtllib_name,
                                               tobj_mtl_source *out);
 
+/* Pull-style byte input. read returns TOBJ_OK and writes 0 bytes at EOF. The
+ * loader owns neither callbacks nor user_data, but calls close when non-NULL. */
+typedef struct tobj_io_callbacks {
+  tobj_result (*read)(void *ud, uint8_t *dst, size_t dst_size,
+                      size_t *bytes_read);
+  void (*close)(void *ud);
+  void *user_data;
+} tobj_io_callbacks;
+
 /* Load configuration (precision-independent: it has no real fields). */
 typedef struct tobj_load_config {
   tobj_allocator allocator;     /* {0} -> default libc allocator */
@@ -176,6 +188,7 @@ typedef struct tobj_load_config {
   size_t max_materials;
   size_t max_shapes;
   size_t max_line_bytes;
+  size_t max_input_bytes;
 
   tobj_material_resolver mtl_resolver;
   void *mtl_resolver_user_data;
@@ -232,6 +245,7 @@ typedef tobj_material_list_d tobj_material_list;
 #define tobj_load_obj_from_file(...) tobj_load_obj_from_file_d(__VA_ARGS__)
 #define tobj_load_obj_with_callbacks(...) \
   tobj_load_obj_with_callbacks_d(__VA_ARGS__)
+#define tobj_load_obj_from_io(...) tobj_load_obj_from_io_d(__VA_ARGS__)
 #define tobj_scene_free(...) tobj_scene_free_d(__VA_ARGS__)
 #define tobj_parse_mtl_from_memory(...) tobj_parse_mtl_from_memory_d(__VA_ARGS__)
 #define tobj_material_list_free(...) tobj_material_list_free_d(__VA_ARGS__)
@@ -254,6 +268,7 @@ typedef tobj_material_list_f tobj_material_list;
 #define tobj_load_obj_from_file(...) tobj_load_obj_from_file_f(__VA_ARGS__)
 #define tobj_load_obj_with_callbacks(...) \
   tobj_load_obj_with_callbacks_f(__VA_ARGS__)
+#define tobj_load_obj_from_io(...) tobj_load_obj_from_io_f(__VA_ARGS__)
 #define tobj_scene_free(...) tobj_scene_free_f(__VA_ARGS__)
 #define tobj_parse_mtl_from_memory(...) tobj_parse_mtl_from_memory_f(__VA_ARGS__)
 #define tobj_material_list_free(...) tobj_material_list_free_f(__VA_ARGS__)

--- a/tiny_obj_c_impl.inc
+++ b/tiny_obj_c_impl.inc
@@ -1528,17 +1528,11 @@ tobj_result TOBJ_T(tobj_load_obj_from_memory)(TOBJ_T(tobj_scene) * out,
     defcfg = tobj_default_config();
     cfg = &defcfg;
   }
+  if (len > tobj_resolve_caps(cfg).input_bytes) return TOBJ_ERR_LIMIT_EXCEEDED;
 
   tobj_allocator alloc;
-  if (cfg->allocator.alloc) {
-    alloc = cfg->allocator;
-  } else {
-#ifndef TOBJ_NO_LIBC
-    alloc = tobj_default_allocator();
-#else
+  if (!tobj_resolve_allocator(&cfg->allocator, &alloc))
     return TOBJ_ERR_INVALID_ARG;
-#endif
-  }
 
   tobj_arena *arena = (tobj_arena *)tobj_alloc(&alloc, sizeof(tobj_arena), 16);
   if (!arena) return TOBJ_ERR_ALLOC;
@@ -1641,6 +1635,60 @@ tobj_result TOBJ_T(tobj_load_obj_from_memory)(TOBJ_T(tobj_scene) * out,
   return TOBJ_OK;
 }
 
+tobj_result TOBJ_T(tobj_load_obj_from_io)(TOBJ_T(tobj_scene) * out,
+                                          const tobj_io_callbacks *io,
+                                          const tobj_load_config *cfg,
+                                          tobj_diag *diag) {
+  if (!out) return TOBJ_ERR_INVALID_ARG;
+  tobj_memset(out, 0, sizeof *out);
+  if (!io || !io->read) return TOBJ_ERR_INVALID_ARG;
+
+  tobj_load_config cc = cfg ? *cfg : tobj_default_config();
+  tobj_allocator alloc;
+  if (!tobj_resolve_allocator(&cc.allocator, &alloc))
+    return TOBJ_ERR_INVALID_ARG;
+  cc.allocator = alloc;
+
+  tobj_caps caps = tobj_resolve_caps(&cc);
+  tobj_vec buf;
+  tobj_vec_init(&buf, 1);
+  tobj_result r = TOBJ_OK;
+
+  for (;;) {
+    size_t remain = caps.input_bytes - buf.count;
+    if (remain == 0) {
+      uint8_t extra;
+      size_t got = 0;
+      r = io->read(io->user_data, &extra, 1, &got);
+      if (r == TOBJ_OK && got != 0) r = TOBJ_ERR_LIMIT_EXCEEDED;
+      break;
+    }
+    size_t want = remain < (size_t)(64u * 1024u) ? remain
+                                                  : (size_t)(64u * 1024u);
+    size_t old = buf.count;
+    if (!tobj_vec_reserve(&buf, old + want, &alloc)) {
+      r = TOBJ_ERR_ALLOC;
+      break;
+    }
+    size_t got = 0;
+    r = io->read(io->user_data, (uint8_t *)buf.data + old, want, &got);
+    if (r != TOBJ_OK) break;
+    if (got > want) {
+      r = TOBJ_ERR_IO;
+      break;
+    }
+    if (got == 0) break;
+    buf.count = old + got;
+  }
+
+  if (io->close) io->close(io->user_data);
+  if (r == TOBJ_OK)
+    r = TOBJ_T(tobj_load_obj_from_memory)(out, (const uint8_t *)buf.data,
+                                          buf.count, &cc, diag);
+  tobj_vec_free(&buf, &alloc);
+  return r;
+}
+
 #ifdef TOBJ_ENABLE_FILE_IO
 tobj_result TOBJ_T(tobj_load_obj_from_file)(TOBJ_T(tobj_scene) * out,
                                             const char *path,
@@ -1652,15 +1700,13 @@ tobj_result TOBJ_T(tobj_load_obj_from_file)(TOBJ_T(tobj_scene) * out,
 
   tobj_load_config cc = cfg ? *cfg : tobj_default_config();
   tobj_allocator alloc;
-  if (cc.allocator.alloc) {
-    alloc = cc.allocator;
-  } else {
-    alloc = tobj_default_allocator();
-    cc.allocator = alloc;
-  }
+  if (!tobj_resolve_allocator(&cc.allocator, &alloc))
+    return TOBJ_ERR_INVALID_ARG;
+  cc.allocator = alloc;
 
   tobj_file_buf fb;
-  tobj_result r = tobj_file_open(&fb, path, &alloc);
+  tobj_result r = tobj_file_open(&fb, path, &alloc,
+                                 tobj_resolve_caps(&cc).input_bytes);
   if (r != TOBJ_OK) return r;
 
   size_t dlen;
@@ -1672,6 +1718,7 @@ tobj_result TOBJ_T(tobj_load_obj_from_file)(TOBJ_T(tobj_scene) * out,
   tobj_file_res_ctx ctx;
   ctx.basedir = basedir;
   ctx.alloc = alloc;
+  ctx.max_bytes = tobj_resolve_caps(&cc).input_bytes;
   if (!cc.mtl_resolver) {
     cc.mtl_resolver = tobj_file_material_resolver;
     cc.mtl_resolver_user_data = &ctx;
@@ -1702,16 +1749,10 @@ tobj_result TOBJ_T(tobj_parse_mtl_from_memory)(TOBJ_T(tobj_material_list) * out,
     defcfg = tobj_default_config();
     cfg = &defcfg;
   }
+  if (len > tobj_resolve_caps(cfg).input_bytes) return TOBJ_ERR_LIMIT_EXCEEDED;
   tobj_allocator alloc;
-  if (cfg->allocator.alloc) {
-    alloc = cfg->allocator;
-  } else {
-#ifndef TOBJ_NO_LIBC
-    alloc = tobj_default_allocator();
-#else
+  if (!tobj_resolve_allocator(&cfg->allocator, &alloc))
     return TOBJ_ERR_INVALID_ARG;
-#endif
-  }
   tobj_arena *arena = (tobj_arena *)tobj_alloc(&alloc, sizeof(tobj_arena), 16);
   if (!arena) return TOBJ_ERR_ALLOC;
   tobj_arena_init(arena, &alloc, 0);
@@ -1775,16 +1816,10 @@ tobj_result TOBJ_T(tobj_load_obj_with_callbacks)(
     defcfg = tobj_default_config();
     cfg = &defcfg;
   }
+  if (len > tobj_resolve_caps(cfg).input_bytes) return TOBJ_ERR_LIMIT_EXCEEDED;
   tobj_allocator alloc;
-  if (cfg->allocator.alloc) {
-    alloc = cfg->allocator;
-  } else {
-#ifndef TOBJ_NO_LIBC
-    alloc = tobj_default_allocator();
-#else
+  if (!tobj_resolve_allocator(&cfg->allocator, &alloc))
     return TOBJ_ERR_INVALID_ARG;
-#endif
-  }
   tobj_arena *arena = (tobj_arena *)tobj_alloc(&alloc, sizeof(tobj_arena), 16);
   if (!arena) return TOBJ_ERR_ALLOC;
   tobj_arena_init(arena, &alloc, 0);

--- a/tiny_obj_c_pub.inc
+++ b/tiny_obj_c_pub.inc
@@ -253,6 +253,10 @@ TOBJ_API tobj_result TOBJ_T(tobj_load_obj_from_memory)(
     TOBJ_T(tobj_scene) * out, const uint8_t *buf, size_t len,
     const tobj_load_config *cfg, tobj_diag *diag);
 
+TOBJ_API tobj_result TOBJ_T(tobj_load_obj_from_io)(
+    TOBJ_T(tobj_scene) * out, const tobj_io_callbacks *io,
+    const tobj_load_config *cfg, tobj_diag *diag);
+
 #ifdef TOBJ_ENABLE_FILE_IO
 TOBJ_API tobj_result TOBJ_T(tobj_load_obj_from_file)(
     TOBJ_T(tobj_scene) * out, const char *path, const tobj_load_config *cfg,


### PR DESCRIPTION
## Summary
- add bounded/aligned allocator hooks and optional custom byte I/O callbacks for the C11 loader
- enforce input-size limits across memory, file, MTL, and callback paths
- add regression tests for allocator failures, invalid allocator structs, and callback I/O edge cases

## Tests
- env ASAN_OPTIONS=detect_leaks=0 make -C tests check_c